### PR TITLE
Fix exporter audit findings

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,8 @@ jobs:
 
       - name: Lint
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
+        with:
+          version: v2.11.4
 
       - name: Verify dependencies
         run: go mod verify

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -138,5 +138,8 @@ git config core.hooksPath .githooks
   processing behavior. Add focused tests before behavior changes.
 - `WatchLogFile` and `main` still need refactoring before they can be tested
   cleanly.
+- Host/upstream label cardinality and `TopHosts.counter` remain unbounded by
+  design for now. This has not caused observed production issues; revisit with
+  an explicit metric-semantics design before changing dashboard-facing metrics.
 - The exporter is intentionally file-log based; adding API calls or Kubernetes
   clients should be treated as a scope expansion.

--- a/config/config.go
+++ b/config/config.go
@@ -25,7 +25,11 @@ func LoadConfig() Config {
 
 	if envMetricsPort := os.Getenv("METRICS_PORT"); envMetricsPort != "" {
 		if port, err := strconv.Atoi(envMetricsPort); err == nil {
-			config.MetricsPort = port
+			if port >= 1 && port <= 65535 {
+				config.MetricsPort = port
+			} else {
+				log.Printf("Invalid METRICS_PORT value: %s. Using default: %d", envMetricsPort, config.MetricsPort)
+			}
 		} else {
 			log.Printf("Invalid METRICS_PORT value: %s. Using default: %d", envMetricsPort, config.MetricsPort)
 		}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -49,3 +49,21 @@ func TestLoadConfigFallsBackToDefaultPortWhenEnvPortIsInvalid(t *testing.T) {
 		t.Fatalf("expected invalid metrics port to fall back to 8000, got %d", cfg.MetricsPort)
 	}
 }
+
+func TestLoadConfigFallsBackToDefaultPortWhenEnvPortIsOutOfRange(t *testing.T) {
+	tests := []string{"0", "-1", "65536"}
+
+	for _, envPort := range tests {
+		t.Run(envPort, func(t *testing.T) {
+			t.Setenv("LOG_FILE_PATH", "")
+			t.Setenv("METRICS_PORT", envPort)
+			t.Setenv("LOG_LEVEL", "")
+
+			cfg := LoadConfig()
+
+			if cfg.MetricsPort != 8000 {
+				t.Fatalf("expected out-of-range metrics port %q to fall back to 8000, got %d", envPort, cfg.MetricsPort)
+			}
+		})
+	}
+}

--- a/loghandler/loghandler.go
+++ b/loghandler/loghandler.go
@@ -36,7 +36,7 @@ func NewLogHandler(logFilePath string, metricsCollector *metrics.MetricsCollecto
 func (lh *LogHandler) initialLoad() {
 	if _, err := os.Stat(lh.logFilePath); err == nil {
 		log.Printf("Loading existing log file: %s", lh.logFilePath)
-		lh.fileExists = true
+		lh.setFileExists(true)
 		lh.processNewLines()
 	} else {
 		log.Printf("Waiting for log file: %s", lh.logFilePath)
@@ -55,6 +55,17 @@ func (lh *LogHandler) processNewLines() {
 	}
 	defer file.Close()
 
+	info, err := file.Stat()
+	if err != nil {
+		log.Printf("Error stating log file: %v", err)
+		lh.healthStatus = false
+		return
+	}
+	if info.Size() < lh.lastPosition {
+		log.Printf("Log file was truncated; resetting read position from %d to 0", lh.lastPosition)
+		lh.lastPosition = 0
+	}
+
 	_, err = file.Seek(lh.lastPosition, io.SeekStart)
 	if err != nil {
 		log.Printf("Error seeking in log file: %v", err)
@@ -62,28 +73,47 @@ func (lh *LogHandler) processNewLines() {
 		return
 	}
 
-	scanner := bufio.NewScanner(file)
-	for scanner.Scan() {
-		var data map[string]interface{}
-		if err := json.Unmarshal(scanner.Bytes(), &data); err != nil {
-			log.Printf("Error decoding JSON: %v", err)
-			continue
+	reader := bufio.NewReader(file)
+	for {
+		line, err := reader.ReadBytes('\n')
+		if len(line) > 0 {
+			lh.processLine(line)
 		}
-		// Ensure Upstream is present and not empty
-		if upstream, ok := data["Upstream"]; !ok || upstream == "" {
-			data["Upstream"] = "unknown"
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			log.Printf("Error reading log file: %v", err)
+			lh.healthStatus = false
+			return
 		}
-		lh.metricsCollector.UpdateMetrics(data)
 	}
 
-	if err := scanner.Err(); err != nil {
-		log.Printf("Error reading log file: %v", err)
+	position, err := file.Seek(0, io.SeekCurrent)
+	if err != nil {
+		log.Printf("Error recording log file position: %v", err)
 		lh.healthStatus = false
 		return
 	}
-
-	lh.lastPosition, _ = file.Seek(0, io.SeekCurrent)
+	lh.lastPosition = position
 	lh.healthStatus = true
+}
+
+func (lh *LogHandler) processLine(line []byte) {
+	if len(line) == 0 {
+		return
+	}
+
+	var data map[string]interface{}
+	if err := json.Unmarshal(line, &data); err != nil {
+		log.Printf("Error decoding JSON: %v", err)
+		return
+	}
+	// Ensure Upstream is present and not empty
+	if upstream, ok := data["Upstream"]; !ok || upstream == "" {
+		data["Upstream"] = "unknown"
+	}
+	lh.metricsCollector.UpdateMetrics(data)
 }
 
 func (lh *LogHandler) WatchLogFile() {
@@ -108,15 +138,14 @@ func (lh *LogHandler) WatchLogFile() {
 					lh.processNewLines()
 				} else if event.Op&fsnotify.Create == fsnotify.Create {
 					log.Printf("Log file created: %s", event.Name)
-					lh.fileExists = true
-					lh.lastPosition = 0
+					lh.resetForCreatedFile()
 					lh.processNewLines()
 				}
 			case err, ok := <-watcher.Errors:
 				if !ok {
 					return
 				}
-				lh.healthStatus = false
+				lh.setHealth(false)
 				log.Println("error:", err)
 			}
 		}
@@ -135,4 +164,24 @@ func (lh *LogHandler) IsHealthy() bool {
 	lh.lock.Lock()
 	defer lh.lock.Unlock()
 	return lh.healthStatus
+}
+
+func (lh *LogHandler) setHealth(healthy bool) {
+	lh.lock.Lock()
+	defer lh.lock.Unlock()
+	lh.healthStatus = healthy
+}
+
+func (lh *LogHandler) setFileExists(exists bool) {
+	lh.lock.Lock()
+	defer lh.lock.Unlock()
+	lh.fileExists = exists
+}
+
+func (lh *LogHandler) resetForCreatedFile() {
+	lh.lock.Lock()
+	defer lh.lock.Unlock()
+	lh.fileExists = true
+	lh.lastPosition = 0
+	lh.healthStatus = true
 }

--- a/loghandler/loghandler.go
+++ b/loghandler/loghandler.go
@@ -2,6 +2,7 @@ package loghandler
 
 import (
 	"bufio"
+	"bytes"
 	"encoding/json"
 	"io"
 	"log"
@@ -13,10 +14,13 @@ import (
 	"github.com/sholdee/adguard-exporter/metrics"
 )
 
+const logFingerprintBytes = 4096
+
 type LogHandler struct {
 	logFilePath      string
 	metricsCollector *metrics.MetricsCollector
 	lastPosition     int64
+	lastFingerprint  []byte
 	healthStatus     bool
 	fileExists       bool
 	lock             sync.Mutex
@@ -61,9 +65,10 @@ func (lh *LogHandler) processNewLines() {
 		lh.healthStatus = false
 		return
 	}
-	if info.Size() < lh.lastPosition {
-		log.Printf("Log file was truncated; resetting read position from %d to 0", lh.lastPosition)
-		lh.lastPosition = 0
+	if err := lh.ensureReadPosition(file, info.Size()); err != nil {
+		log.Printf("Error verifying log file position: %v", err)
+		lh.healthStatus = false
+		return
 	}
 
 	_, err = file.Seek(lh.lastPosition, io.SeekStart)
@@ -74,29 +79,91 @@ func (lh *LogHandler) processNewLines() {
 	}
 
 	reader := bufio.NewReader(file)
+	position := lh.lastPosition
 	for {
+		lineStart := position
 		line, err := reader.ReadBytes('\n')
-		if len(line) > 0 {
+		if err == nil {
 			lh.processLine(line)
+			position += int64(len(line))
+			continue
 		}
-		if err != nil {
-			if err == io.EOF {
-				break
-			}
-			log.Printf("Error reading log file: %v", err)
-			lh.healthStatus = false
-			return
-		}
-	}
 
-	position, err := file.Seek(0, io.SeekCurrent)
-	if err != nil {
-		log.Printf("Error recording log file position: %v", err)
+		if err == io.EOF {
+			if len(line) > 0 {
+				position = lineStart
+			}
+			break
+		}
+
+		log.Printf("Error reading log file: %v", err)
 		lh.healthStatus = false
 		return
 	}
+
 	lh.lastPosition = position
+	if err := lh.refreshFingerprint(file); err != nil {
+		log.Printf("Error recording log file fingerprint: %v", err)
+		lh.healthStatus = false
+		return
+	}
 	lh.healthStatus = true
+}
+
+func (lh *LogHandler) ensureReadPosition(file *os.File, size int64) error {
+	if lh.lastPosition == 0 {
+		return nil
+	}
+	if size < lh.lastPosition {
+		log.Printf("Log file was truncated; resetting read position from %d to 0", lh.lastPosition)
+		lh.resetReadPosition()
+		return nil
+	}
+	if len(lh.lastFingerprint) == 0 {
+		return nil
+	}
+
+	fingerprint, err := readLogFingerprint(file, lh.lastPosition)
+	if err != nil {
+		return err
+	}
+	if !bytes.Equal(fingerprint, lh.lastFingerprint) {
+		log.Printf("Log file changed before read position; resetting read position from %d to 0", lh.lastPosition)
+		lh.resetReadPosition()
+	}
+	return nil
+}
+
+func (lh *LogHandler) refreshFingerprint(file *os.File) error {
+	fingerprint, err := readLogFingerprint(file, lh.lastPosition)
+	if err != nil {
+		return err
+	}
+	lh.lastFingerprint = fingerprint
+	return nil
+}
+
+func (lh *LogHandler) resetReadPosition() {
+	lh.lastPosition = 0
+	lh.lastFingerprint = nil
+}
+
+func readLogFingerprint(file *os.File, position int64) ([]byte, error) {
+	if position <= 0 {
+		return nil, nil
+	}
+
+	length := int64(logFingerprintBytes)
+	if position < length {
+		length = position
+	}
+
+	fingerprint := make([]byte, length)
+	n, err := file.ReadAt(fingerprint, position-length)
+	if err != nil && err != io.EOF {
+		return nil, err
+	}
+	return fingerprint[:n], nil
 }
 
 func (lh *LogHandler) processLine(line []byte) {
@@ -182,6 +249,6 @@ func (lh *LogHandler) resetForCreatedFile() {
 	lh.lock.Lock()
 	defer lh.lock.Unlock()
 	lh.fileExists = true
-	lh.lastPosition = 0
+	lh.resetReadPosition()
 	lh.healthStatus = true
 }

--- a/loghandler/loghandler_test.go
+++ b/loghandler/loghandler_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -79,6 +80,47 @@ func TestProcessNewLinesSkipsMalformedJSONAndStaysHealthy(t *testing.T) {
 	}
 }
 
+func TestProcessNewLinesHandlesLargeQueryLogRecords(t *testing.T) {
+	resetMetricsForLogHandlerTest(t)
+	logFilePath := filepath.Join(t.TempDir(), "querylog.json")
+	writeLogFile(t, logFilePath,
+		largeQueryLogLine("large.example", "A", strings.Repeat("a", 70*1024)),
+		queryLogLine("after-large.example", "AAAA", false, 0, 10_000_000, "1.1.1.1"),
+	)
+
+	handler := NewLogHandler(logFilePath, metrics.NewMetricsCollector())
+
+	if !handler.IsHealthy() {
+		t.Fatal("expected large query log record to be processed without making handler unhealthy")
+	}
+	if got := testutil.ToFloat64(metrics.DNSQueries.Counter); got != 2 {
+		t.Fatalf("expected large and following records to update metrics, got %f", got)
+	}
+	if handler.lastPosition == 0 {
+		t.Fatal("expected handler to advance last read position after large record")
+	}
+}
+
+func TestProcessNewLinesResetsOffsetWhenLogIsTruncated(t *testing.T) {
+	resetMetricsForLogHandlerTest(t)
+	logFilePath := filepath.Join(t.TempDir(), "querylog.json")
+	writeLogFile(t, logFilePath, largeQueryLogLine("before-truncate.example", "A", strings.Repeat("a", 1024)))
+	handler := NewLogHandler(logFilePath, metrics.NewMetricsCollector())
+
+	writeLogFile(t, logFilePath, queryLogLine("after-truncate.example", "AAAA", false, 0, 20_000_000, "1.1.1.1"))
+	handler.processNewLines()
+
+	if !handler.IsHealthy() {
+		t.Fatal("expected handler to remain healthy after processing truncated log")
+	}
+	if got := testutil.ToFloat64(metrics.DNSQueries.Counter); got != 2 {
+		t.Fatalf("expected truncated log to be read from beginning, got %f DNS queries", got)
+	}
+	if got := testutil.ToFloat64(metrics.QueryTypes.WithLabelValues("AAAA")); got != 1 {
+		t.Fatalf("expected query after truncation to be processed, got %f", got)
+	}
+}
+
 func TestNewLogHandlerMissingFileStartsHealthyAndAbsent(t *testing.T) {
 	resetMetricsForLogHandlerTest(t)
 	logFilePath := filepath.Join(t.TempDir(), "missing-querylog.json")
@@ -110,6 +152,15 @@ func queryLogLine(host, queryType string, blocked bool, reason int, elapsedNs in
 		upstreamField,
 		blocked,
 		reason,
+	)
+}
+
+func largeQueryLogLine(host, queryType string, answer string) string {
+	return fmt.Sprintf(
+		`{"QH":%q,"QT":%q,"Elapsed":10000000,"Upstream":"1.1.1.1","Answer":%q,"Result":{"IsFiltered":false,"Reason":0}}`,
+		host,
+		queryType,
+		answer,
 	)
 }
 

--- a/loghandler/loghandler_test.go
+++ b/loghandler/loghandler_test.go
@@ -121,6 +121,49 @@ func TestProcessNewLinesResetsOffsetWhenLogIsTruncated(t *testing.T) {
 	}
 }
 
+func TestProcessNewLinesWaitsForPartialFinalLine(t *testing.T) {
+	resetMetricsForLogHandlerTest(t)
+	logFilePath := filepath.Join(t.TempDir(), "querylog.json")
+	partial := `{"QH":"partial.example","QT":"A","Elapsed":10000000,"Upstream":"1.1.1.1","Result":{"IsFiltered":false`
+	if err := os.WriteFile(logFilePath, []byte(partial), 0o600); err != nil {
+		t.Fatalf("write partial log file: %v", err)
+	}
+	handler := NewLogHandler(logFilePath, metrics.NewMetricsCollector())
+
+	if got := testutil.ToFloat64(metrics.DNSQueries.Counter); got != 0 {
+		t.Fatalf("expected partial line not to be processed, got %f DNS queries", got)
+	}
+
+	appendLogFragment(t, logFilePath, `,"Reason":0}}`+"\n")
+	handler.processNewLines()
+
+	if got := testutil.ToFloat64(metrics.DNSQueries.Counter); got != 1 {
+		t.Fatalf("expected completed partial line to be processed once, got %f", got)
+	}
+	if got := testutil.ToFloat64(metrics.QueryTypes.WithLabelValues("A")); got != 1 {
+		t.Fatalf("expected completed partial A query to be processed once, got %f", got)
+	}
+}
+
+func TestProcessNewLinesResetsOffsetWhenTruncatedLogRegrowsPastOldOffset(t *testing.T) {
+	resetMetricsForLogHandlerTest(t)
+	logFilePath := filepath.Join(t.TempDir(), "querylog.json")
+	writeLogFile(t, logFilePath, largeQueryLogLine("old.example", "A", strings.Repeat("a", 128)))
+	handler := NewLogHandler(logFilePath, metrics.NewMetricsCollector())
+	oldPosition := handler.lastPosition
+
+	newLine := largeQueryLogLine("after-regrow.example", "AAAA", strings.Repeat("b", int(oldPosition)))
+	writeLogFile(t, logFilePath, newLine)
+	handler.processNewLines()
+
+	if got := testutil.ToFloat64(metrics.DNSQueries.Counter); got != 2 {
+		t.Fatalf("expected regrown truncated log to be read from beginning, got %f DNS queries", got)
+	}
+	if got := testutil.ToFloat64(metrics.QueryTypes.WithLabelValues("AAAA")); got != 1 {
+		t.Fatalf("expected query after truncate/regrow to be processed, got %f", got)
+	}
+}
+
 func TestNewLogHandlerMissingFileStartsHealthyAndAbsent(t *testing.T) {
 	resetMetricsForLogHandlerTest(t)
 	logFilePath := filepath.Join(t.TempDir(), "missing-querylog.json")
@@ -191,6 +234,20 @@ func appendLogLine(t *testing.T, path string, line string) {
 
 	if _, err := fmt.Fprintln(file, line); err != nil {
 		t.Fatalf("append log line: %v", err)
+	}
+}
+
+func appendLogFragment(t *testing.T, path string, fragment string) {
+	t.Helper()
+
+	file, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0)
+	if err != nil {
+		t.Fatalf("open log file for append: %v", err)
+	}
+	defer file.Close()
+
+	if _, err := file.WriteString(fragment); err != nil {
+		t.Fatalf("append log fragment: %v", err)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -28,6 +28,8 @@ func main() {
 
 	// Register metrics
 	metricsCollector := metrics.NewMetricsCollector()
+	metricsCtx, stopMetrics := context.WithCancel(context.Background())
+	metricsCollector.StartProcessing(metricsCtx, 30*time.Second)
 	prometheus.MustRegister(metrics.DNSQueries.Counter, metrics.DNSQueries.Created)
 	prometheus.MustRegister(metrics.BlockedQueries.Counter, metrics.BlockedQueries.Created)
 	prometheus.MustRegister(metrics.QueryTypes.CounterVec, metrics.QueryTypes.CreatedVec)
@@ -43,8 +45,9 @@ func main() {
 	go logHandler.WatchLogFile()
 
 	// Set up HTTP server for metrics and health checks
-	http.Handle("/metrics", promhttp.Handler())
-	http.HandleFunc("/livez", func(w http.ResponseWriter, r *http.Request) {
+	mux := http.NewServeMux()
+	mux.Handle("/metrics", promhttp.Handler())
+	mux.HandleFunc("/livez", func(w http.ResponseWriter, r *http.Request) {
 		if logHandler.IsHealthy() {
 			w.WriteHeader(http.StatusOK)
 			fmt.Fprint(w, "Alive")
@@ -53,17 +56,14 @@ func main() {
 			fmt.Fprint(w, "Unhealthy")
 		}
 	})
-	http.HandleFunc("/readyz", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/readyz", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		fmt.Fprint(w, "Ready")
 	})
 
 	// Start the HTTP server
 	serverAddr := fmt.Sprintf(":%d", cfg.MetricsPort)
-	server := &http.Server{
-		Addr:    serverAddr,
-		Handler: http.DefaultServeMux,
-	}
+	server := newHTTPServer(serverAddr, mux)
 
 	// Graceful shutdown
 	stop := make(chan os.Signal, 1)
@@ -78,6 +78,7 @@ func main() {
 
 	<-stop
 	log.Println("Shutting down the server...")
+	stopMetrics()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	if err := server.Shutdown(ctx); err != nil {
 		cancel()
@@ -86,4 +87,15 @@ func main() {
 	cancel()
 
 	log.Println("Server exiting")
+}
+
+func newHTTPServer(addr string, handler http.Handler) *http.Server {
+	return &http.Server{
+		Addr:              addr,
+		Handler:           handler,
+		ReadHeaderTimeout: 5 * time.Second,
+		ReadTimeout:       10 * time.Second,
+		WriteTimeout:      10 * time.Second,
+		IdleTimeout:       60 * time.Second,
+	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestNewHTTPServerConfiguresTimeouts(t *testing.T) {
+	server := newHTTPServer(":8000", http.NewServeMux())
+
+	if server.ReadHeaderTimeout == 0 {
+		t.Fatal("expected ReadHeaderTimeout to be configured")
+	}
+	if server.ReadTimeout == 0 {
+		t.Fatal("expected ReadTimeout to be configured")
+	}
+	if server.WriteTimeout == 0 {
+		t.Fatal("expected WriteTimeout to be configured")
+	}
+	if server.IdleTimeout == 0 {
+		t.Fatal("expected IdleTimeout to be configured")
+	}
+}

--- a/metrics/collector.go
+++ b/metrics/collector.go
@@ -51,6 +51,7 @@ type MetricsCollector struct {
 	responseTimes         []TimeValue
 	upstreamResponseTimes map[string][]TimeValue
 	windowSize            int64
+	processLock           sync.Mutex
 	lock                  sync.Mutex
 }
 
@@ -125,6 +126,9 @@ func (mc *MetricsCollector) StartProcessing(ctx context.Context, interval time.D
 }
 
 func (mc *MetricsCollector) ProcessMetrics() {
+	mc.processLock.Lock()
+	defer mc.processLock.Unlock()
+
 	currentTime := time.Now().Unix()
 	cutoffTime := currentTime - mc.windowSize
 

--- a/metrics/collector.go
+++ b/metrics/collector.go
@@ -1,6 +1,7 @@
 package metrics
 
 import (
+	"context"
 	"fmt"
 	"sync"
 	"time"
@@ -100,6 +101,29 @@ func (mc *MetricsCollector) UpdateMetrics(data map[string]interface{}) {
 	mc.ProcessMetrics()
 }
 
+func (mc *MetricsCollector) StartProcessing(ctx context.Context, interval time.Duration) <-chan struct{} {
+	done := make(chan struct{})
+	if interval <= 0 {
+		close(done)
+		return done
+	}
+
+	ticker := time.NewTicker(interval)
+	go func() {
+		defer close(done)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				mc.ProcessMetrics()
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+	return done
+}
+
 func (mc *MetricsCollector) ProcessMetrics() {
 	currentTime := time.Now().Unix()
 	cutoffTime := currentTime - mc.windowSize
@@ -121,8 +145,11 @@ func (mc *MetricsCollector) ProcessMetrics() {
 	if len(recentResponseTimes) > 0 {
 		avgResponseTime := mc.calculateAverage(recentResponseTimes)
 		AverageResponseTime.Set(avgResponseTime)
+	} else {
+		AverageResponseTime.Set(0)
 	}
 
+	recentUpstreamResponseTimes := make(map[string][]TimeValue, len(mc.upstreamResponseTimes))
 	for upstream, times := range mc.upstreamResponseTimes {
 		if upstream == "unknown" || upstream == "" {
 			continue // Skip processing for unknown upstreams
@@ -131,13 +158,14 @@ func (mc *MetricsCollector) ProcessMetrics() {
 		if len(recentTimes) > 0 {
 			avgUpstreamTime := mc.calculateAverage(recentTimes)
 			AverageUpstreamResponseTime.WithLabelValues(upstream).Set(avgUpstreamTime)
+			recentUpstreamResponseTimes[upstream] = recentTimes
+		} else {
+			AverageUpstreamResponseTime.DeleteLabelValues(upstream)
 		}
 	}
 
 	mc.responseTimes = recentResponseTimes
-	for upstream := range mc.upstreamResponseTimes {
-		mc.upstreamResponseTimes[upstream] = mc.filterRecentTimes(mc.upstreamResponseTimes[upstream], cutoffTime)
-	}
+	mc.upstreamResponseTimes = recentUpstreamResponseTimes
 }
 
 func (mc *MetricsCollector) filterRecentTimes(times []TimeValue, cutoffTime int64) []TimeValue {

--- a/metrics/collector_test.go
+++ b/metrics/collector_test.go
@@ -2,6 +2,8 @@ package metrics
 
 import (
 	"context"
+	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -168,6 +170,33 @@ func TestStartProcessingClearsExpiredAveragesWithoutNewQueries(t *testing.T) {
 			t.Fatalf("expected background processing to clear expired average, got %f", testutil.ToFloat64(AverageResponseTime))
 		default:
 			time.Sleep(time.Millisecond)
+		}
+	}
+}
+
+func TestProcessMetricsSerializesTopHostResetAndAdd(t *testing.T) {
+	resetMetricsForTest(t)
+	collector := NewMetricsCollector()
+	for i := range 100 {
+		host := fmt.Sprintf("host-%03d.example", i)
+		collector.topHosts.Add(host)
+	}
+
+	for range 100 {
+		var wg sync.WaitGroup
+		for range 8 {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				collector.ProcessMetrics()
+			}()
+		}
+		wg.Wait()
+
+		for _, hostCount := range collector.topHosts.GetTop() {
+			if got := testutil.ToFloat64(TopQueryHosts.WithLabelValues(hostCount.Host)); got != float64(hostCount.Count) {
+				t.Fatalf("expected serialized top-host metric for %s to equal %d, got %f", hostCount.Host, hostCount.Count, got)
+			}
 		}
 	}
 }

--- a/metrics/collector_test.go
+++ b/metrics/collector_test.go
@@ -1,6 +1,7 @@
 package metrics
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -115,6 +116,59 @@ func TestProcessMetricsDropsExpiredResponseTimes(t *testing.T) {
 	}
 	if got := testutil.ToFloat64(AverageUpstreamResponseTime.WithLabelValues("1.1.1.1")); got != 30 {
 		t.Fatalf("expected upstream average response time 30ms, got %f", got)
+	}
+}
+
+func TestProcessMetricsClearsExpiredResponseTimeGauges(t *testing.T) {
+	resetMetricsForTest(t)
+	collector := NewMetricsCollector()
+	now := time.Now().Unix()
+	collector.responseTimes = []TimeValue{{Time: now - 600, Value: 100}}
+	collector.upstreamResponseTimes["1.1.1.1"] = []TimeValue{{Time: now - 600, Value: 100}}
+	AverageResponseTime.Set(42)
+	AverageUpstreamResponseTime.WithLabelValues("1.1.1.1").Set(42)
+
+	collector.ProcessMetrics()
+
+	if len(collector.responseTimes) != 0 {
+		t.Fatalf("expected expired response times to be removed, got %#v", collector.responseTimes)
+	}
+	if _, exists := collector.upstreamResponseTimes["1.1.1.1"]; exists {
+		t.Fatalf("expected expired upstream response times to be removed, got %#v", collector.upstreamResponseTimes)
+	}
+	if got := testutil.ToFloat64(AverageResponseTime); got != 0 {
+		t.Fatalf("expected expired average response time gauge to clear to 0, got %f", got)
+	}
+	if got := testutil.ToFloat64(AverageUpstreamResponseTime.WithLabelValues("1.1.1.1")); got != 0 {
+		t.Fatalf("expected expired upstream average response time gauge to clear to 0, got %f", got)
+	}
+}
+
+func TestStartProcessingClearsExpiredAveragesWithoutNewQueries(t *testing.T) {
+	resetMetricsForTest(t)
+	collector := NewMetricsCollector()
+	collector.responseTimes = []TimeValue{{Time: time.Now().Unix() - 600, Value: 100}}
+	AverageResponseTime.Set(42)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := collector.StartProcessing(ctx, time.Millisecond)
+	defer func() {
+		cancel()
+		<-done
+	}()
+
+	deadline := time.After(200 * time.Millisecond)
+	for {
+		if got := testutil.ToFloat64(AverageResponseTime); got == 0 {
+			return
+		}
+
+		select {
+		case <-deadline:
+			t.Fatalf("expected background processing to clear expired average, got %f", testutil.ToFloat64(AverageResponseTime))
+		default:
+			time.Sleep(time.Millisecond)
+		}
 	}
 }
 

--- a/metrics/custom_counter_test.go
+++ b/metrics/custom_counter_test.go
@@ -32,3 +32,18 @@ func TestCustomCounterVecWithLabels(t *testing.T) {
 		t.Fatalf("expected labeled counter value 4, got %f", got)
 	}
 }
+
+func TestCustomCounterVecCreatedTimestampIsSetOnlyOnce(t *testing.T) {
+	counterVec := NewCustomCounterVec(prometheus.CounterOpts{
+		Name: "test_custom_counter_vec_created_once_total",
+		Help: "Test custom counter vec created timestamp",
+	}, []string{"label"})
+
+	counterVec.WithLabelValues("value").Inc()
+	counterVec.CreatedVec.WithLabelValues("value").Set(123)
+	counterVec.WithLabelValues("value").Inc()
+
+	if got := testutil.ToFloat64(counterVec.CreatedVec.WithLabelValues("value")); got != 123 {
+		t.Fatalf("expected created timestamp to stay at 123, got %f", got)
+	}
+}

--- a/metrics/custom_counter_test.go
+++ b/metrics/custom_counter_test.go
@@ -47,3 +47,18 @@ func TestCustomCounterVecCreatedTimestampIsSetOnlyOnce(t *testing.T) {
 		t.Fatalf("expected created timestamp to stay at 123, got %f", got)
 	}
 }
+
+func TestCustomCounterVecCreatedTimestampIsSharedAcrossAccessMethods(t *testing.T) {
+	counterVec := NewCustomCounterVec(prometheus.CounterOpts{
+		Name: "test_custom_counter_vec_created_shared_total",
+		Help: "Test custom counter vec shared created timestamp",
+	}, []string{"label"})
+
+	counterVec.WithLabelValues("value").Inc()
+	counterVec.CreatedVec.WithLabelValues("value").Set(123)
+	counterVec.With(prometheus.Labels{"label": "value"}).Inc()
+
+	if got := testutil.ToFloat64(counterVec.CreatedVec.WithLabelValues("value")); got != 123 {
+		t.Fatalf("expected created timestamp to stay at 123 across access methods, got %f", got)
+	}
+}

--- a/metrics/custom_counter_vec.go
+++ b/metrics/custom_counter_vec.go
@@ -1,12 +1,19 @@
 package metrics
 
 import (
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+
 	"github.com/prometheus/client_golang/prometheus"
 )
 
 type CustomCounterVec struct {
 	CounterVec *prometheus.CounterVec
 	CreatedVec *prometheus.GaugeVec
+	created    map[string]struct{}
+	lock       sync.Mutex
 }
 
 func NewCustomCounterVec(opts prometheus.CounterOpts, labelNames []string) *CustomCounterVec {
@@ -19,15 +26,64 @@ func NewCustomCounterVec(opts prometheus.CounterOpts, labelNames []string) *Cust
 	return &CustomCounterVec{
 		CounterVec: counterVec,
 		CreatedVec: createdVec,
+		created:    make(map[string]struct{}),
 	}
 }
 
 func (ccv *CustomCounterVec) WithLabelValues(lvs ...string) prometheus.Counter {
-	ccv.CreatedVec.WithLabelValues(lvs...).SetToCurrentTime()
+	ccv.setCreatedOnce(labelValuesKey(lvs), func() {
+		ccv.CreatedVec.WithLabelValues(lvs...).SetToCurrentTime()
+	})
 	return ccv.CounterVec.WithLabelValues(lvs...)
 }
 
 func (ccv *CustomCounterVec) With(labels prometheus.Labels) prometheus.Counter {
-	ccv.CreatedVec.With(labels).SetToCurrentTime()
+	ccv.setCreatedOnce(labelsKey(labels), func() {
+		ccv.CreatedVec.With(labels).SetToCurrentTime()
+	})
 	return ccv.CounterVec.With(labels)
+}
+
+func (ccv *CustomCounterVec) setCreatedOnce(key string, setCreated func()) {
+	ccv.lock.Lock()
+	defer ccv.lock.Unlock()
+
+	if _, exists := ccv.created[key]; exists {
+		return
+	}
+	setCreated()
+	ccv.created[key] = struct{}{}
+}
+
+func labelValuesKey(values []string) string {
+	var builder strings.Builder
+	for _, value := range values {
+		builder.WriteString(strconv.Itoa(len(value)))
+		builder.WriteByte(':')
+		builder.WriteString(value)
+		builder.WriteByte(';')
+	}
+	return builder.String()
+}
+
+func labelsKey(labels prometheus.Labels) string {
+	keys := make([]string, 0, len(labels))
+	for key := range labels {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	var builder strings.Builder
+	for _, key := range keys {
+		builder.WriteString(strconv.Itoa(len(key)))
+		builder.WriteByte(':')
+		builder.WriteString(key)
+		builder.WriteByte('=')
+		value := labels[key]
+		builder.WriteString(strconv.Itoa(len(value)))
+		builder.WriteByte(':')
+		builder.WriteString(value)
+		builder.WriteByte(';')
+	}
+	return builder.String()
 }

--- a/metrics/custom_counter_vec.go
+++ b/metrics/custom_counter_vec.go
@@ -1,7 +1,6 @@
 package metrics
 
 import (
-	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -13,32 +12,35 @@ type CustomCounterVec struct {
 	CounterVec *prometheus.CounterVec
 	CreatedVec *prometheus.GaugeVec
 	created    map[string]struct{}
+	labelNames []string
 	lock       sync.Mutex
 }
 
 func NewCustomCounterVec(opts prometheus.CounterOpts, labelNames []string) *CustomCounterVec {
-	counterVec := prometheus.NewCounterVec(opts, labelNames)
+	labelNamesCopy := append([]string(nil), labelNames...)
+	counterVec := prometheus.NewCounterVec(opts, labelNamesCopy)
 	createdOpts := prometheus.GaugeOpts{
 		Name: opts.Name[:len(opts.Name)-6] + "_created",
 		Help: opts.Help + " (created timestamp)",
 	}
-	createdVec := prometheus.NewGaugeVec(createdOpts, labelNames)
+	createdVec := prometheus.NewGaugeVec(createdOpts, labelNamesCopy)
 	return &CustomCounterVec{
 		CounterVec: counterVec,
 		CreatedVec: createdVec,
 		created:    make(map[string]struct{}),
+		labelNames: labelNamesCopy,
 	}
 }
 
 func (ccv *CustomCounterVec) WithLabelValues(lvs ...string) prometheus.Counter {
-	ccv.setCreatedOnce(labelValuesKey(lvs), func() {
+	ccv.setCreatedOnce(labelValuesKey(ccv.labelNames, lvs), func() {
 		ccv.CreatedVec.WithLabelValues(lvs...).SetToCurrentTime()
 	})
 	return ccv.CounterVec.WithLabelValues(lvs...)
 }
 
 func (ccv *CustomCounterVec) With(labels prometheus.Labels) prometheus.Counter {
-	ccv.setCreatedOnce(labelsKey(labels), func() {
+	ccv.setCreatedOnce(labelsKey(ccv.labelNames, labels), func() {
 		ccv.CreatedVec.With(labels).SetToCurrentTime()
 	})
 	return ccv.CounterVec.With(labels)
@@ -55,35 +57,38 @@ func (ccv *CustomCounterVec) setCreatedOnce(key string, setCreated func()) {
 	ccv.created[key] = struct{}{}
 }
 
-func labelValuesKey(values []string) string {
+func labelValuesKey(labelNames []string, values []string) string {
 	var builder strings.Builder
-	for _, value := range values {
-		builder.WriteString(strconv.Itoa(len(value)))
-		builder.WriteByte(':')
-		builder.WriteString(value)
-		builder.WriteByte(';')
+	for index, labelName := range labelNames {
+		value := ""
+		if index < len(values) {
+			value = values[index]
+		}
+		writeLabelKeyPart(&builder, labelName, value)
+	}
+	if len(values) > len(labelNames) {
+		for _, value := range values[len(labelNames):] {
+			writeLabelKeyPart(&builder, "", value)
+		}
 	}
 	return builder.String()
 }
 
-func labelsKey(labels prometheus.Labels) string {
-	keys := make([]string, 0, len(labels))
-	for key := range labels {
-		keys = append(keys, key)
-	}
-	sort.Strings(keys)
-
+func labelsKey(labelNames []string, labels prometheus.Labels) string {
 	var builder strings.Builder
-	for _, key := range keys {
-		builder.WriteString(strconv.Itoa(len(key)))
-		builder.WriteByte(':')
-		builder.WriteString(key)
-		builder.WriteByte('=')
-		value := labels[key]
-		builder.WriteString(strconv.Itoa(len(value)))
-		builder.WriteByte(':')
-		builder.WriteString(value)
-		builder.WriteByte(';')
+	for _, labelName := range labelNames {
+		writeLabelKeyPart(&builder, labelName, labels[labelName])
 	}
 	return builder.String()
+}
+
+func writeLabelKeyPart(builder *strings.Builder, labelName, value string) {
+	builder.WriteString(strconv.Itoa(len(labelName)))
+	builder.WriteByte(':')
+	builder.WriteString(labelName)
+	builder.WriteByte('=')
+	builder.WriteString(strconv.Itoa(len(value)))
+	builder.WriteByte(':')
+	builder.WriteString(value)
+	builder.WriteByte(';')
 }


### PR DESCRIPTION
## Summary
- harden query log tailing for large records, partial final lines, and truncate/regrow cases
- serialize metrics recomputation to avoid top-host reset/add interleaving
- keep custom counter _created timestamps stable across label access methods
- add regression coverage for the reviewed audit findings

## Verification
- go test ./...
- go test -race ./...
- go vet ./...
- go mod verify
- golangci-lint run
- actionlint -shellcheck=shellcheck
- markdownlint-cli2
- renovate-config-validator --strict
- govulncheck ./...
- git diff --check

Review agent approved after follow-up commit 6350965.