### PR TITLE
Refactor watcher and health route wiring for testability

### DIFF
--- a/loghandler/loghandler.go
+++ b/loghandler/loghandler.go
@@ -3,7 +3,9 @@ package loghandler
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"log"
 	"os"
@@ -15,6 +17,11 @@ import (
 )
 
 const logFingerprintBytes = 4096
+
+type LogWatcher interface {
+	Run(context.Context)
+	Close() error
+}
 
 type LogHandler struct {
 	logFilePath      string
@@ -183,48 +190,83 @@ func (lh *LogHandler) processLine(line []byte) {
 	lh.metricsCollector.UpdateMetrics(data)
 }
 
-func (lh *LogHandler) WatchLogFile() {
-	watcher, err := fsnotify.NewWatcher()
+func (lh *LogHandler) WatchLogFile(ctx context.Context) error {
+	watcher, err := lh.NewLogWatcher()
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
-
-	done := make(chan bool)
-	go func() {
-		for {
-			select {
-			case event, ok := <-watcher.Events:
-				if !ok {
-					return
-				}
-				// Check if the event is for our specific file
-				if filepath.Base(event.Name) != filepath.Base(lh.logFilePath) {
-					continue // Ignore events for other files
-				}
-				if event.Op&fsnotify.Write == fsnotify.Write {
-					lh.processNewLines()
-				} else if event.Op&fsnotify.Create == fsnotify.Create {
-					log.Printf("Log file created: %s", event.Name)
-					lh.resetForCreatedFile()
-					lh.processNewLines()
-				}
-			case err, ok := <-watcher.Errors:
-				if !ok {
-					return
-				}
-				lh.setHealth(false)
-				log.Println("error:", err)
-			}
+	defer func() {
+		if err := watcher.Close(); err != nil {
+			log.Printf("Error closing log file watcher: %v", err)
 		}
 	}()
 
-	err = watcher.Add(filepath.Dir(lh.logFilePath))
+	watcher.Run(ctx)
+	return nil
+}
+
+func (lh *LogHandler) NewLogWatcher() (LogWatcher, error) {
+	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
-		_ = watcher.Close()
-		log.Fatal(err)
+		lh.setHealth(false)
+		return nil, fmt.Errorf("create log file watcher: %w", err)
 	}
-	defer watcher.Close()
-	<-done
+
+	if err := watcher.Add(filepath.Dir(lh.logFilePath)); err != nil {
+		if closeErr := watcher.Close(); closeErr != nil {
+			log.Printf("Error closing log file watcher after setup failure: %v", closeErr)
+		}
+		lh.setHealth(false)
+		return nil, fmt.Errorf("watch log file directory: %w", err)
+	}
+
+	return &fsLogWatcher{handler: lh, watcher: watcher}, nil
+}
+
+type fsLogWatcher struct {
+	handler *LogHandler
+	watcher *fsnotify.Watcher
+}
+
+func (w *fsLogWatcher) Run(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case event, ok := <-w.watcher.Events:
+			if !ok {
+				return
+			}
+			w.handler.handleWatchEvent(event)
+		case err, ok := <-w.watcher.Errors:
+			if !ok {
+				return
+			}
+			w.handler.handleWatchError(err)
+		}
+	}
+}
+
+func (w *fsLogWatcher) Close() error {
+	return w.watcher.Close()
+}
+
+func (lh *LogHandler) handleWatchEvent(event fsnotify.Event) {
+	if filepath.Base(event.Name) != filepath.Base(lh.logFilePath) {
+		return
+	}
+	if event.Op&fsnotify.Write == fsnotify.Write {
+		lh.processNewLines()
+	} else if event.Op&fsnotify.Create == fsnotify.Create {
+		log.Printf("Log file created: %s", event.Name)
+		lh.resetForCreatedFile()
+		lh.processNewLines()
+	}
+}
+
+func (lh *LogHandler) handleWatchError(err error) {
+	lh.setHealth(false)
+	log.Println("error:", err)
 }
 
 func (lh *LogHandler) IsHealthy() bool {

--- a/loghandler/loghandler_test.go
+++ b/loghandler/loghandler_test.go
@@ -1,12 +1,16 @@
 package loghandler
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/fsnotify/fsnotify"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/sholdee/adguard-exporter/metrics"
@@ -178,6 +182,109 @@ func TestNewLogHandlerMissingFileStartsHealthyAndAbsent(t *testing.T) {
 	}
 	if got := testutil.ToFloat64(metrics.DNSQueries.Counter); got != 0 {
 		t.Fatalf("expected missing log file not to update metrics, got %f", got)
+	}
+}
+
+func TestHandleWatchEventProcessesWriteEventForLogFile(t *testing.T) {
+	resetMetricsForLogHandlerTest(t)
+	logFilePath := filepath.Join(t.TempDir(), "querylog.json")
+	writeLogFile(t, logFilePath, queryLogLine("initial.example", "A", false, 0, 10_000_000, "1.1.1.1"))
+	handler := NewLogHandler(logFilePath, metrics.NewMetricsCollector())
+
+	appendLogLine(t, logFilePath, queryLogLine("written.example", "AAAA", false, 0, 20_000_000, "1.1.1.1"))
+	handler.handleWatchEvent(fsnotify.Event{Name: logFilePath, Op: fsnotify.Write})
+
+	if got := testutil.ToFloat64(metrics.DNSQueries.Counter); got != 2 {
+		t.Fatalf("expected write event to process appended log line, got %f DNS queries", got)
+	}
+	if got := testutil.ToFloat64(metrics.QueryTypes.WithLabelValues("AAAA")); got != 1 {
+		t.Fatalf("expected write event to process appended AAAA query, got %f", got)
+	}
+}
+
+func TestHandleWatchEventProcessesCreateEventForLogFile(t *testing.T) {
+	resetMetricsForLogHandlerTest(t)
+	logFilePath := filepath.Join(t.TempDir(), "querylog.json")
+	handler := NewLogHandler(logFilePath, metrics.NewMetricsCollector())
+
+	writeLogFile(t, logFilePath, queryLogLine("created.example", "A", false, 0, 10_000_000, "1.1.1.1"))
+	handler.handleWatchEvent(fsnotify.Event{Name: logFilePath, Op: fsnotify.Create})
+
+	if !handler.fileExists {
+		t.Fatal("expected create event to mark log file as present")
+	}
+	if got := testutil.ToFloat64(metrics.DNSQueries.Counter); got != 1 {
+		t.Fatalf("expected create event to process new log file, got %f DNS queries", got)
+	}
+}
+
+func TestHandleWatchEventIgnoresUnrelatedFiles(t *testing.T) {
+	resetMetricsForLogHandlerTest(t)
+	dir := t.TempDir()
+	logFilePath := filepath.Join(dir, "querylog.json")
+	writeLogFile(t, logFilePath, queryLogLine("initial.example", "A", false, 0, 10_000_000, "1.1.1.1"))
+	handler := NewLogHandler(logFilePath, metrics.NewMetricsCollector())
+
+	appendLogLine(t, logFilePath, queryLogLine("unread.example", "AAAA", false, 0, 20_000_000, "1.1.1.1"))
+	handler.handleWatchEvent(fsnotify.Event{Name: filepath.Join(dir, "other.json"), Op: fsnotify.Write})
+
+	if got := testutil.ToFloat64(metrics.DNSQueries.Counter); got != 1 {
+		t.Fatalf("expected unrelated event to leave appended log unread, got %f DNS queries", got)
+	}
+}
+
+func TestHandleWatchErrorMarksHandlerUnhealthy(t *testing.T) {
+	resetMetricsForLogHandlerTest(t)
+	logFilePath := filepath.Join(t.TempDir(), "missing-querylog.json")
+	handler := NewLogHandler(logFilePath, metrics.NewMetricsCollector())
+
+	handler.handleWatchError(errors.New("watch failed"))
+
+	if handler.IsHealthy() {
+		t.Fatal("expected watcher error to mark handler unhealthy")
+	}
+}
+
+func TestWatchLogFileReturnsWhenContextCanceled(t *testing.T) {
+	resetMetricsForLogHandlerTest(t)
+	logFilePath := filepath.Join(t.TempDir(), "missing-querylog.json")
+	handler := NewLogHandler(logFilePath, metrics.NewMetricsCollector())
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	errc := make(chan error, 1)
+	go func() {
+		errc <- handler.WatchLogFile(ctx)
+	}()
+
+	select {
+	case err := <-errc:
+		if err != nil {
+			t.Fatalf("expected canceled watcher to return cleanly, got %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("expected canceled watcher to return")
+	}
+}
+
+func TestNewLogWatcherReturnsErrorForMissingDirectory(t *testing.T) {
+	resetMetricsForLogHandlerTest(t)
+	logFilePath := filepath.Join(t.TempDir(), "missing", "querylog.json")
+	handler := NewLogHandler(logFilePath, metrics.NewMetricsCollector())
+
+	watcher, err := handler.NewLogWatcher()
+
+	if err == nil {
+		if closeErr := watcher.Close(); closeErr != nil {
+			t.Fatalf("close unexpected watcher: %v", closeErr)
+		}
+		t.Fatal("expected missing watch directory to return an error")
+	}
+	if watcher != nil {
+		t.Fatal("expected no watcher when setup fails")
+	}
+	if handler.IsHealthy() {
+		t.Fatal("expected watcher setup failure to mark handler unhealthy")
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -42,24 +42,16 @@ func main() {
 	logHandler := loghandler.NewLogHandler(cfg.LogFilePath, metricsCollector)
 
 	// Start watching the log file
-	go logHandler.WatchLogFile()
+	watchCtx, stopWatch := context.WithCancel(context.Background())
+	watchDone, err := startLogWatcher(watchCtx, logHandler.NewLogWatcher)
+	if err != nil {
+		stopMetrics()
+		stopWatch()
+		log.Fatalf("Error watching log file: %v", err)
+	}
 
 	// Set up HTTP server for metrics and health checks
-	mux := http.NewServeMux()
-	mux.Handle("/metrics", promhttp.Handler())
-	mux.HandleFunc("/livez", func(w http.ResponseWriter, r *http.Request) {
-		if logHandler.IsHealthy() {
-			w.WriteHeader(http.StatusOK)
-			fmt.Fprint(w, "Alive")
-		} else {
-			w.WriteHeader(http.StatusServiceUnavailable)
-			fmt.Fprint(w, "Unhealthy")
-		}
-	})
-	mux.HandleFunc("/readyz", func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		fmt.Fprint(w, "Ready")
-	})
+	mux := newMetricsMux(logHandler, promhttp.Handler())
 
 	// Start the HTTP server
 	serverAddr := fmt.Sprintf(":%d", cfg.MetricsPort)
@@ -79,14 +71,69 @@ func main() {
 	<-stop
 	log.Println("Shutting down the server...")
 	stopMetrics()
+	stopWatch()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	if err := server.Shutdown(ctx); err != nil {
 		cancel()
 		log.Fatalf("Server forced to shutdown: %v", err)
 	}
 	cancel()
+	if !waitForLogWatcher(watchDone, 5*time.Second) {
+		log.Println("Timed out waiting for log watcher to stop")
+	}
 
 	log.Println("Server exiting")
+}
+
+func startLogWatcher(ctx context.Context, newWatcher func() (loghandler.LogWatcher, error)) (<-chan struct{}, error) {
+	watcher, err := newWatcher()
+	if err != nil {
+		return nil, err
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		defer func() {
+			if err := watcher.Close(); err != nil {
+				log.Printf("Error closing log file watcher: %v", err)
+			}
+		}()
+		watcher.Run(ctx)
+	}()
+	return done, nil
+}
+
+func waitForLogWatcher(done <-chan struct{}, timeout time.Duration) bool {
+	select {
+	case <-done:
+		return true
+	case <-time.After(timeout):
+		return false
+	}
+}
+
+type logHealth interface {
+	IsHealthy() bool
+}
+
+func newMetricsMux(logHandler logHealth, metricsHandler http.Handler) *http.ServeMux {
+	mux := http.NewServeMux()
+	mux.Handle("/metrics", metricsHandler)
+	mux.HandleFunc("/livez", func(w http.ResponseWriter, r *http.Request) {
+		if logHandler.IsHealthy() {
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, "Alive")
+		} else {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			fmt.Fprint(w, "Unhealthy")
+		}
+	})
+	mux.HandleFunc("/readyz", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, "Ready")
+	})
+	return mux
 }
 
 func newHTTPServer(addr string, handler http.Handler) *http.Server {

--- a/main_test.go
+++ b/main_test.go
@@ -1,9 +1,111 @@
 package main
 
 import (
+	"context"
+	"errors"
+	"fmt"
 	"net/http"
+	"net/http/httptest"
 	"testing"
+	"time"
+
+	"github.com/sholdee/adguard-exporter/loghandler"
 )
+
+type stubLogHealth struct {
+	healthy bool
+}
+
+func (s stubLogHealth) IsHealthy() bool {
+	return s.healthy
+}
+
+type stubLogWatcherFactory struct {
+	watcher loghandler.LogWatcher
+	err     error
+}
+
+func (s stubLogWatcherFactory) NewLogWatcher() (loghandler.LogWatcher, error) {
+	return s.watcher, s.err
+}
+
+type stubLogWatcher struct {
+	runStarted  chan struct{}
+	closeCalled chan struct{}
+}
+
+func (s stubLogWatcher) Run(ctx context.Context) {
+	close(s.runStarted)
+	<-ctx.Done()
+}
+
+func (s stubLogWatcher) Close() error {
+	close(s.closeCalled)
+	return nil
+}
+
+func TestStartLogWatcherReturnsSetupError(t *testing.T) {
+	wantErr := errors.New("watch setup failed")
+
+	done, err := startLogWatcher(context.Background(), stubLogWatcherFactory{err: wantErr}.NewLogWatcher)
+
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("expected setup error %v, got %v", wantErr, err)
+	}
+	if done != nil {
+		t.Fatal("expected no watcher done channel when setup fails")
+	}
+}
+
+func TestStartLogWatcherRunsUntilContextCanceledAndClosesWatcher(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	watcher := stubLogWatcher{
+		runStarted:  make(chan struct{}),
+		closeCalled: make(chan struct{}),
+	}
+
+	done, err := startLogWatcher(ctx, stubLogWatcherFactory{watcher: watcher}.NewLogWatcher)
+	if err != nil {
+		t.Fatalf("start watcher: %v", err)
+	}
+
+	select {
+	case <-watcher.runStarted:
+	case <-time.After(time.Second):
+		t.Fatal("expected watcher to start running")
+	}
+
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("expected watcher to stop after cancellation")
+	}
+
+	select {
+	case <-watcher.closeCalled:
+	default:
+		t.Fatal("expected watcher to be closed after Run returns")
+	}
+}
+
+func TestWaitForLogWatcherTimesOut(t *testing.T) {
+	done := make(chan struct{})
+
+	if waitForLogWatcher(done, time.Nanosecond) {
+		t.Fatal("expected watcher wait to time out")
+	}
+}
+
+func TestWaitForLogWatcherReturnsWhenDone(t *testing.T) {
+	done := make(chan struct{})
+	close(done)
+
+	if !waitForLogWatcher(done, time.Second) {
+		t.Fatal("expected watcher wait to observe closed done channel")
+	}
+}
 
 func TestNewHTTPServerConfiguresTimeouts(t *testing.T) {
 	server := newHTTPServer(":8000", http.NewServeMux())
@@ -19,5 +121,77 @@ func TestNewHTTPServerConfiguresTimeouts(t *testing.T) {
 	}
 	if server.IdleTimeout == 0 {
 		t.Fatal("expected IdleTimeout to be configured")
+	}
+}
+
+func TestNewMetricsMuxReportsLivenessFromLogHandler(t *testing.T) {
+	tests := []struct {
+		name       string
+		healthy    bool
+		wantStatus int
+		wantBody   string
+	}{
+		{
+			name:       "healthy",
+			healthy:    true,
+			wantStatus: http.StatusOK,
+			wantBody:   "Alive",
+		},
+		{
+			name:       "unhealthy",
+			healthy:    false,
+			wantStatus: http.StatusServiceUnavailable,
+			wantBody:   "Unhealthy",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mux := newMetricsMux(stubLogHealth{healthy: tt.healthy}, http.NotFoundHandler())
+			response := httptest.NewRecorder()
+			request := httptest.NewRequest(http.MethodGet, "/livez", nil)
+
+			mux.ServeHTTP(response, request)
+
+			if response.Code != tt.wantStatus {
+				t.Fatalf("expected status %d, got %d", tt.wantStatus, response.Code)
+			}
+			if body := response.Body.String(); body != tt.wantBody {
+				t.Fatalf("expected body %q, got %q", tt.wantBody, body)
+			}
+		})
+	}
+}
+
+func TestNewMetricsMuxReportsReadiness(t *testing.T) {
+	mux := newMetricsMux(stubLogHealth{healthy: false}, http.NotFoundHandler())
+	response := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+
+	mux.ServeHTTP(response, request)
+
+	if response.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d", http.StatusOK, response.Code)
+	}
+	if body := response.Body.String(); body != "Ready" {
+		t.Fatalf("expected body %q, got %q", "Ready", body)
+	}
+}
+
+func TestNewMetricsMuxUsesProvidedMetricsHandler(t *testing.T) {
+	mux := newMetricsMux(stubLogHealth{healthy: true}, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusAccepted)
+		fmt.Fprint(w, "metrics")
+	}))
+	response := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+
+	mux.ServeHTTP(response, request)
+
+	if response.Code != http.StatusAccepted {
+		t.Fatalf("expected status %d, got %d", http.StatusAccepted, response.Code)
+	}
+	if body := response.Body.String(); body != "metrics" {
+		t.Fatalf("expected body %q, got %q", "metrics", body)
 	}
 }


### PR DESCRIPTION
## Summary
- make log watcher setup synchronous and testable while preserving fatal startup failure behavior
- add cancellable watcher runtime and bounded watcher shutdown wait
- extract health/metrics route wiring into a testable mux helper
- add focused tests for watcher events, setup failure, cancellation/close, bounded waits, and health endpoints
