### PR TITLE
Align querylog metrics with AdGuard semantics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,8 +50,8 @@ putting HTTP concerns into `metrics`.
 - AdGuard query log format assumptions:
   - inspect `loghandler/loghandler.go`
   - inspect `metrics/collector.go`
-  - current fields used: `QH`, `QT`, `Result.IsFiltered`, `Result.Reason`,
-    `Elapsed`, `Upstream`
+  - current fields used: `T`/legacy `Time`, `QH`, `QT`, `Result.IsFiltered`,
+    `Result.Reason`, `Elapsed`, `Upstream`, `Cached`
 - Runtime configuration:
   - update `config/config.go`
   - update Dockerfile `ENV` defaults if applicable
@@ -65,8 +65,9 @@ Do not scan `assets/` unless the README image itself is part of the task.
 
 ## High-Risk Areas
 
-- Log parsing is loosely typed. Bad or changed AdGuard fields may silently turn
-  into zero values.
+- Log parsing uses a typed subset of AdGuard's internal querylog schema. The
+  schema is not a versioned public contract, so keep parse/skip behavior
+  explicit when adding fields.
 - Label cardinality can grow quickly for host and upstream labels.
 - Top-host metrics are reset and repopulated from in-memory state; be careful
   with Prometheus counter semantics.
@@ -136,8 +137,9 @@ git config core.hooksPath .githooks
 
 - Unit tests cover `config`, most of `metrics`, and core `loghandler` file
   processing behavior. Add focused tests before behavior changes.
-- `WatchLogFile` and `main` still need refactoring before they can be tested
-  cleanly.
+- `WatchLogFile` and health-route wiring have focused tests. Keep future
+  watcher changes cancellable and avoid hiding watcher startup failures behind
+  successful readiness.
 - Host/upstream label cardinality and `TopHosts.counter` remain unbounded by
   design for now. This has not caused observed production issues; revisit with
   an explicit metric-semantics design before changing dashboard-facing metrics.

--- a/README.md
+++ b/README.md
@@ -45,14 +45,20 @@ up the partial registry state manually before retrying.
 
 ```text
 agh_dns_queries_total: Total number of DNS queries
-agh_blocked_dns_queries_total: Total number of blocked DNS queries
+agh_blocked_dns_queries_total: Total number of AdGuard blocked queries
 agh_dns_query_types_total: DNS query types and respective counts
 agh_dns_query_hosts_total: Top 100 DNS query hosts
 agh_blocked_dns_query_hosts_total: Top 100 blocked DNS query hosts
 agh_safe_search_enforced_hosts_total: Safe search enforced hosts
+agh_dns_filtering_reason_total: DNS query filtering reasons
+agh_querylog_entries_skipped_total: Query log entries skipped by reason
 agh_dns_average_response_time: Average response time of all queries in ms
-agh_dns_average_upstream_response_time: Average upstream response time in ms
+agh_dns_average_upstream_response_time: Query processing time by upstream in ms
 ```
+
+The upstream timing metric keeps its historical name, but it is based on
+querylog `Elapsed` grouped by `Upstream`; AdGuard Home querylog records do not
+include pure upstream round-trip duration.
 
 ## How To Use This Container
 

--- a/loghandler/loghandler.go
+++ b/loghandler/loghandler.go
@@ -45,6 +45,12 @@ func NewLogHandler(logFilePath string, metricsCollector *metrics.MetricsCollecto
 }
 
 func (lh *LogHandler) initialLoad() {
+	rotatedLogFilePath := lh.logFilePath + ".1"
+	if _, err := os.Stat(rotatedLogFilePath); err == nil {
+		log.Printf("Loading rotated log file: %s", rotatedLogFilePath)
+		lh.processHistoricalFile(rotatedLogFilePath)
+	}
+
 	if _, err := os.Stat(lh.logFilePath); err == nil {
 		log.Printf("Loading existing log file: %s", lh.logFilePath)
 		lh.setFileExists(true)
@@ -52,6 +58,33 @@ func (lh *LogHandler) initialLoad() {
 	} else {
 		log.Printf("Waiting for log file: %s", lh.logFilePath)
 	}
+}
+
+func (lh *LogHandler) processHistoricalFile(path string) {
+	file, err := os.Open(path)
+	if err != nil {
+		log.Printf("Error opening historical log file: %v", err)
+		lh.setHealth(false)
+		return
+	}
+	defer file.Close()
+
+	reader := bufio.NewReader(file)
+	for {
+		line, err := reader.ReadBytes('\n')
+		if len(line) > 0 {
+			lh.processLine(line)
+		}
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			log.Printf("Error reading historical log file: %v", err)
+			lh.setHealth(false)
+			return
+		}
+	}
+	lh.setHealth(true)
 }
 
 func (lh *LogHandler) processNewLines() {
@@ -178,16 +211,18 @@ func (lh *LogHandler) processLine(line []byte) {
 		return
 	}
 
-	var data map[string]interface{}
-	if err := json.Unmarshal(line, &data); err != nil {
+	var entry metrics.QueryLogEntry
+	if err := json.Unmarshal(line, &entry); err != nil {
 		log.Printf("Error decoding JSON: %v", err)
+		metrics.QueryLogEntriesSkipped.WithLabelValues("invalid_json").Inc()
 		return
 	}
-	// Ensure Upstream is present and not empty
-	if upstream, ok := data["Upstream"]; !ok || upstream == "" {
-		data["Upstream"] = "unknown"
+	if skipReason := entry.SkipReason(); skipReason != "" {
+		log.Printf("Skipping query log entry: %s", skipReason)
+		metrics.QueryLogEntriesSkipped.WithLabelValues(skipReason).Inc()
+		return
 	}
-	lh.metricsCollector.UpdateMetrics(data)
+	lh.metricsCollector.UpdateMetrics(entry)
 }
 
 func (lh *LogHandler) WatchLogFile(ctx context.Context) error {

--- a/loghandler/loghandler_test.go
+++ b/loghandler/loghandler_test.go
@@ -46,6 +46,28 @@ func TestNewLogHandlerInitialLoadProcessesExistingLogFile(t *testing.T) {
 	}
 }
 
+func TestNewLogHandlerInitialLoadProcessesRotatedAndCurrentLogFiles(t *testing.T) {
+	resetMetricsForLogHandlerTest(t)
+	logFilePath := filepath.Join(t.TempDir(), "querylog.json")
+	writeLogFile(t, logFilePath+".1", queryLogLine("rotated.example", "A", false, 0, 25_000_000, "1.1.1.1"))
+	writeLogFile(t, logFilePath, queryLogLine("current.example", "AAAA", false, 0, 50_000_000, "1.1.1.1"))
+
+	handler := NewLogHandler(logFilePath, metrics.NewMetricsCollector())
+
+	if !handler.fileExists {
+		t.Fatal("expected handler to mark current log file as present")
+	}
+	if got := testutil.ToFloat64(metrics.DNSQueries.Counter); got != 2 {
+		t.Fatalf("expected rotated and current logs to be loaded, got %f DNS queries", got)
+	}
+	if got := testutil.ToFloat64(metrics.QueryTypes.WithLabelValues("A")); got != 1 {
+		t.Fatalf("expected rotated A query to be counted once, got %f", got)
+	}
+	if got := testutil.ToFloat64(metrics.QueryTypes.WithLabelValues("AAAA")); got != 1 {
+		t.Fatalf("expected current AAAA query to be counted once, got %f", got)
+	}
+}
+
 func TestProcessNewLinesOnlyReadsAppendedLines(t *testing.T) {
 	resetMetricsForLogHandlerTest(t)
 	logFilePath := filepath.Join(t.TempDir(), "querylog.json")
@@ -81,6 +103,90 @@ func TestProcessNewLinesSkipsMalformedJSONAndStaysHealthy(t *testing.T) {
 	}
 	if got := testutil.ToFloat64(metrics.DNSQueries.Counter); got != 1 {
 		t.Fatalf("expected only valid JSON line to update metrics, got %f", got)
+	}
+	if got := testutil.ToFloat64(metrics.QueryLogEntriesSkipped.WithLabelValues("invalid_json")); got != 1 {
+		t.Fatalf("expected malformed JSON to increment skipped entries, got %f", got)
+	}
+}
+
+func TestProcessNewLinesSkipsTypedQueryLogRecordsMissingRequiredFields(t *testing.T) {
+	resetMetricsForLogHandlerTest(t)
+	logFilePath := filepath.Join(t.TempDir(), "querylog.json")
+	writeLogFile(t, logFilePath,
+		fmt.Sprintf(`{"T":%q,"QT":"A","Elapsed":10000000,"Result":{"IsFiltered":false,"Reason":0}}`, time.Now().Format(time.RFC3339Nano)),
+		queryLogLine("valid.example", "A", false, 0, 10_000_000, "1.1.1.1"),
+	)
+
+	handler := NewLogHandler(logFilePath, metrics.NewMetricsCollector())
+
+	if !handler.IsHealthy() {
+		t.Fatal("expected invalid query log records to be skipped without marking handler unhealthy")
+	}
+	if got := testutil.ToFloat64(metrics.DNSQueries.Counter); got != 1 {
+		t.Fatalf("expected only valid query log record to update metrics, got %f", got)
+	}
+	if got := testutil.ToFloat64(metrics.QueryLogEntriesSkipped.WithLabelValues("missing_query_host")); got != 1 {
+		t.Fatalf("expected missing query host to increment skipped entries, got %f", got)
+	}
+}
+
+func TestProcessNewLinesDefaultsOmittedAllowedReason(t *testing.T) {
+	resetMetricsForLogHandlerTest(t)
+	logFilePath := filepath.Join(t.TempDir(), "querylog.json")
+	writeLogFile(t, logFilePath,
+		fmt.Sprintf(
+			`{"T":%q,"QH":"allowed.example","QT":"A","Elapsed":10000000,"Upstream":"1.1.1.1","Result":{}}`,
+			time.Now().Format(time.RFC3339Nano),
+		),
+	)
+
+	NewLogHandler(logFilePath, metrics.NewMetricsCollector())
+
+	if got := testutil.ToFloat64(metrics.DNSQueries.Counter); got != 1 {
+		t.Fatalf("expected omitted reason on allowed query to update metrics, got %f", got)
+	}
+	if got := testutil.ToFloat64(metrics.QueryFilteringReasons.WithLabelValues("not_filtered_not_found")); got != 1 {
+		t.Fatalf("expected omitted allowed reason to default to not filtered, got %f", got)
+	}
+	if got := testutil.ToFloat64(metrics.QueryLogEntriesSkipped.WithLabelValues("missing_reason")); got != 0 {
+		t.Fatalf("expected omitted allowed reason not to be skipped, got %f", got)
+	}
+}
+
+func TestProcessNewLinesSkipsFilteredRecordsMissingReason(t *testing.T) {
+	resetMetricsForLogHandlerTest(t)
+	logFilePath := filepath.Join(t.TempDir(), "querylog.json")
+	writeLogFile(t, logFilePath,
+		fmt.Sprintf(
+			`{"T":%q,"QH":"filtered.example","QT":"A","Elapsed":10000000,"Upstream":"1.1.1.1","Result":{"IsFiltered":true}}`,
+			time.Now().Format(time.RFC3339Nano),
+		),
+	)
+
+	NewLogHandler(logFilePath, metrics.NewMetricsCollector())
+
+	if got := testutil.ToFloat64(metrics.DNSQueries.Counter); got != 0 {
+		t.Fatalf("expected filtered query missing reason to be skipped, got %f", got)
+	}
+	if got := testutil.ToFloat64(metrics.QueryLogEntriesSkipped.WithLabelValues("missing_reason")); got != 1 {
+		t.Fatalf("expected filtered query missing reason to increment skipped entries, got %f", got)
+	}
+}
+
+func TestProcessNewLinesAcceptsLegacyTimeField(t *testing.T) {
+	resetMetricsForLogHandlerTest(t)
+	logFilePath := filepath.Join(t.TempDir(), "querylog.json")
+	writeLogFile(t, logFilePath,
+		fmt.Sprintf(
+			`{"Time":%q,"QH":"legacy.example","QT":"A","Elapsed":10000000,"Upstream":"1.1.1.1","Result":{"IsFiltered":false,"Reason":0}}`,
+			time.Now().Format(time.RFC3339Nano),
+		),
+	)
+
+	NewLogHandler(logFilePath, metrics.NewMetricsCollector())
+
+	if got := testutil.ToFloat64(metrics.DNSQueries.Counter); got != 1 {
+		t.Fatalf("expected legacy Time field record to update metrics, got %f", got)
 	}
 }
 
@@ -128,7 +234,7 @@ func TestProcessNewLinesResetsOffsetWhenLogIsTruncated(t *testing.T) {
 func TestProcessNewLinesWaitsForPartialFinalLine(t *testing.T) {
 	resetMetricsForLogHandlerTest(t)
 	logFilePath := filepath.Join(t.TempDir(), "querylog.json")
-	partial := `{"QH":"partial.example","QT":"A","Elapsed":10000000,"Upstream":"1.1.1.1","Result":{"IsFiltered":false`
+	partial := fmt.Sprintf(`{"T":%q,"QH":"partial.example","QT":"A","Elapsed":10000000,"Upstream":"1.1.1.1","Result":{"IsFiltered":false`, time.Now().Format(time.RFC3339Nano))
 	if err := os.WriteFile(logFilePath, []byte(partial), 0o600); err != nil {
 		t.Fatalf("write partial log file: %v", err)
 	}
@@ -295,7 +401,8 @@ func queryLogLine(host, queryType string, blocked bool, reason int, elapsedNs in
 	}
 
 	return fmt.Sprintf(
-		`{"QH":%q,"QT":%q,"Elapsed":%d%s,"Result":{"IsFiltered":%t,"Reason":%d}}`,
+		`{"T":%q,"QH":%q,"QT":%q,"Elapsed":%d%s,"Result":{"IsFiltered":%t,"Reason":%d}}`,
+		time.Now().Format(time.RFC3339Nano),
 		host,
 		queryType,
 		elapsedNs,
@@ -307,7 +414,8 @@ func queryLogLine(host, queryType string, blocked bool, reason int, elapsedNs in
 
 func largeQueryLogLine(host, queryType string, answer string) string {
 	return fmt.Sprintf(
-		`{"QH":%q,"QT":%q,"Elapsed":10000000,"Upstream":"1.1.1.1","Answer":%q,"Result":{"IsFiltered":false,"Reason":0}}`,
+		`{"T":%q,"QH":%q,"QT":%q,"Elapsed":10000000,"Upstream":"1.1.1.1","Answer":%q,"Result":{"IsFiltered":false,"Reason":0}}`,
+		time.Now().Format(time.RFC3339Nano),
 		host,
 		queryType,
 		answer,
@@ -367,6 +475,8 @@ func resetMetricsForLogHandlerTest(t *testing.T) {
 	oldTopQueryHosts := metrics.TopQueryHosts
 	oldTopBlockedQueryHosts := metrics.TopBlockedQueryHosts
 	oldSafeSearchEnforcedHosts := metrics.SafeSearchEnforcedHosts
+	oldQueryFilteringReasons := metrics.QueryFilteringReasons
+	oldQueryLogEntriesSkipped := metrics.QueryLogEntriesSkipped
 	oldAverageResponseTime := metrics.AverageResponseTime
 	oldAverageUpstreamResponseTime := metrics.AverageUpstreamResponseTime
 	t.Cleanup(func() {
@@ -376,6 +486,8 @@ func resetMetricsForLogHandlerTest(t *testing.T) {
 		metrics.TopQueryHosts = oldTopQueryHosts
 		metrics.TopBlockedQueryHosts = oldTopBlockedQueryHosts
 		metrics.SafeSearchEnforcedHosts = oldSafeSearchEnforcedHosts
+		metrics.QueryFilteringReasons = oldQueryFilteringReasons
+		metrics.QueryLogEntriesSkipped = oldQueryLogEntriesSkipped
 		metrics.AverageResponseTime = oldAverageResponseTime
 		metrics.AverageUpstreamResponseTime = oldAverageUpstreamResponseTime
 	})
@@ -404,6 +516,14 @@ func resetMetricsForLogHandlerTest(t *testing.T) {
 		Name: "agh_safe_search_enforced_hosts_total",
 		Help: "Safe search enforced hosts",
 	}, []string{"host"})
+	metrics.QueryFilteringReasons = metrics.NewCustomCounterVec(prometheus.CounterOpts{
+		Name: "agh_dns_filtering_reason_total",
+		Help: "DNS query filtering reasons",
+	}, []string{"reason"})
+	metrics.QueryLogEntriesSkipped = metrics.NewCustomCounterVec(prometheus.CounterOpts{
+		Name: "agh_querylog_entries_skipped_total",
+		Help: "Query log entries skipped by reason",
+	}, []string{"reason"})
 	metrics.AverageResponseTime = prometheus.NewGauge(prometheus.GaugeOpts{
 		Name: "agh_dns_average_response_time",
 		Help: "Average response time for DNS queries in milliseconds",

--- a/main.go
+++ b/main.go
@@ -36,6 +36,8 @@ func main() {
 	prometheus.MustRegister(metrics.TopQueryHosts.CounterVec, metrics.TopQueryHosts.CreatedVec)
 	prometheus.MustRegister(metrics.TopBlockedQueryHosts.CounterVec, metrics.TopBlockedQueryHosts.CreatedVec)
 	prometheus.MustRegister(metrics.SafeSearchEnforcedHosts.CounterVec, metrics.SafeSearchEnforcedHosts.CreatedVec)
+	prometheus.MustRegister(metrics.QueryFilteringReasons.CounterVec, metrics.QueryFilteringReasons.CreatedVec)
+	prometheus.MustRegister(metrics.QueryLogEntriesSkipped.CounterVec, metrics.QueryLogEntriesSkipped.CreatedVec)
 	prometheus.MustRegister(metrics.AverageResponseTime)
 	prometheus.MustRegister(metrics.AverageUpstreamResponseTime)
 

--- a/metrics/collector.go
+++ b/metrics/collector.go
@@ -2,7 +2,6 @@ package metrics
 
 import (
 	"context"
-	"fmt"
 	"sync"
 	"time"
 
@@ -34,14 +33,21 @@ var (
 		Name: "agh_safe_search_enforced_hosts_total",
 		Help: "Safe search enforced hosts",
 	}, []string{"host"})
-	// Gauges remain unchanged
+	QueryFilteringReasons = NewCustomCounterVec(prometheus.CounterOpts{
+		Name: "agh_dns_filtering_reason_total",
+		Help: "DNS query filtering reasons",
+	}, []string{"reason"})
+	QueryLogEntriesSkipped = NewCustomCounterVec(prometheus.CounterOpts{
+		Name: "agh_querylog_entries_skipped_total",
+		Help: "Query log entries skipped by reason",
+	}, []string{"reason"})
 	AverageResponseTime = prometheus.NewGauge(prometheus.GaugeOpts{
 		Name: "agh_dns_average_response_time",
 		Help: "Average response time for DNS queries in milliseconds",
 	})
 	AverageUpstreamResponseTime = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "agh_dns_average_upstream_response_time",
-		Help: "Average response time by upstream server",
+		Help: "Average query processing time for queries sent to each upstream server in milliseconds",
 	}, []string{"server"})
 )
 
@@ -65,38 +71,38 @@ func NewMetricsCollector() *MetricsCollector {
 	}
 }
 
-func (mc *MetricsCollector) UpdateMetrics(data map[string]interface{}) {
-	currentTime := time.Now().Unix()
-	host, _ := data["QH"].(string)
-	queryType, _ := data["QT"].(string)
-	result, _ := data["Result"].(map[string]interface{})
-	isBlocked, _ := result["IsFiltered"].(bool)
-	resultReason := fmt.Sprintf("%v", result["Reason"])
-	elapsedNs, _ := data["Elapsed"].(float64)
-	upstream, _ := data["Upstream"].(string)
+func (mc *MetricsCollector) UpdateMetrics(entry QueryLogEntry) {
+	if skipReason := entry.SkipReason(); skipReason != "" {
+		QueryLogEntriesSkipped.WithLabelValues(skipReason).Inc()
+		return
+	}
+	entry.Normalize()
+	currentTime := entry.Timestamp().Unix()
+	reason := *entry.Result.Reason
 
 	DNSQueries.Inc()
-	QueryTypes.WithLabelValues(queryType).Inc()
+	QueryTypes.WithLabelValues(entry.QType).Inc()
+	QueryFilteringReasons.WithLabelValues(reason.Label()).Inc()
 
-	if !isBlocked {
-		mc.topHosts.Add(host)
+	if !entry.Result.IsFiltered {
+		mc.topHosts.Add(entry.QHost)
 	}
 
-	elapsedMs := elapsedNs / 1_000_000 // Convert nanoseconds to milliseconds
+	elapsedMs := entry.ElapsedMilliseconds()
 
 	mc.lock.Lock()
 	mc.responseTimes = append(mc.responseTimes, TimeValue{Time: currentTime, Value: elapsedMs})
 	// Exclude metrics with unknown upstreams
-	if upstream != "unknown" && upstream != "" {
-		mc.upstreamResponseTimes[upstream] = append(mc.upstreamResponseTimes[upstream], TimeValue{Time: currentTime, Value: elapsedMs})
+	if !entry.Cached && entry.Upstream != "unknown" {
+		mc.upstreamResponseTimes[entry.Upstream] = append(mc.upstreamResponseTimes[entry.Upstream], TimeValue{Time: currentTime, Value: elapsedMs})
 	}
 	mc.lock.Unlock()
 
-	if isBlocked && resultReason == "7" {
-		SafeSearchEnforcedHosts.WithLabelValues(host).Inc()
-	} else if isBlocked {
+	if reason.IsSafeSearch() {
+		SafeSearchEnforcedHosts.WithLabelValues(entry.QHost).Inc()
+	} else if reason.IsBlocked() {
 		BlockedQueries.Inc()
-		mc.topBlockedHosts.Add(host)
+		mc.topBlockedHosts.Add(entry.QHost)
 	}
 
 	mc.ProcessMetrics()

--- a/metrics/collector_test.go
+++ b/metrics/collector_test.go
@@ -15,7 +15,7 @@ func TestUpdateMetricsTracksAllowedQuery(t *testing.T) {
 	resetMetricsForTest(t)
 	collector := NewMetricsCollector()
 
-	collector.UpdateMetrics(queryLogEntry("allowed.example", "A", false, float64(0), 25_000_000, "1.1.1.1"))
+	collector.UpdateMetrics(queryLogEntry("allowed.example", "A", false, ReasonNotFilteredNotFound, 25_000_000, "1.1.1.1"))
 
 	if got := testutil.ToFloat64(DNSQueries.Counter); got != 1 {
 		t.Fatalf("expected DNS query count 1, got %f", got)
@@ -40,11 +40,30 @@ func TestUpdateMetricsTracksAllowedQuery(t *testing.T) {
 	}
 }
 
+func TestUpdateMetricsDefaultsOmittedAllowedReason(t *testing.T) {
+	resetMetricsForTest(t)
+	collector := NewMetricsCollector()
+	entry := queryLogEntry("allowed.example", "A", false, ReasonNotFilteredNotFound, 25_000_000, "1.1.1.1")
+	entry.Result.Reason = nil
+
+	collector.UpdateMetrics(entry)
+
+	if got := testutil.ToFloat64(DNSQueries.Counter); got != 1 {
+		t.Fatalf("expected omitted reason on allowed query to count DNS query, got %f", got)
+	}
+	if got := testutil.ToFloat64(QueryFilteringReasons.WithLabelValues("not_filtered_not_found")); got != 1 {
+		t.Fatalf("expected omitted allowed reason to default to not filtered, got %f", got)
+	}
+	if got := testutil.ToFloat64(QueryLogEntriesSkipped.WithLabelValues("missing_reason")); got != 0 {
+		t.Fatalf("expected omitted allowed reason not to be skipped, got %f", got)
+	}
+}
+
 func TestUpdateMetricsTracksBlockedQuerySeparately(t *testing.T) {
 	resetMetricsForTest(t)
 	collector := NewMetricsCollector()
 
-	collector.UpdateMetrics(queryLogEntry("blocked.example", "AAAA", true, float64(2), 10_000_000, "9.9.9.9"))
+	collector.UpdateMetrics(queryLogEntry("blocked.example", "AAAA", true, ReasonFilteredBlockList, 10_000_000, "9.9.9.9"))
 
 	if got := testutil.ToFloat64(BlockedQueries.Counter); got != 1 {
 		t.Fatalf("expected blocked query count 1, got %f", got)
@@ -58,13 +77,16 @@ func TestUpdateMetricsTracksBlockedQuerySeparately(t *testing.T) {
 	if got := testutil.ToFloat64(TopBlockedQueryHosts.WithLabelValues("blocked.example")); got != 1 {
 		t.Fatalf("expected top blocked query host metric 1, got %f", got)
 	}
+	if got := testutil.ToFloat64(QueryFilteringReasons.WithLabelValues("filtered_blocklist")); got != 1 {
+		t.Fatalf("expected filtered blocklist reason count 1, got %f", got)
+	}
 }
 
 func TestUpdateMetricsTracksSafeSearchSeparatelyFromBlockedQueries(t *testing.T) {
 	resetMetricsForTest(t)
 	collector := NewMetricsCollector()
 
-	collector.UpdateMetrics(queryLogEntry("safe.example", "A", true, float64(7), 15_000_000, "8.8.8.8"))
+	collector.UpdateMetrics(queryLogEntry("safe.example", "A", true, ReasonFilteredSafeSearch, 15_000_000, "8.8.8.8"))
 
 	if got := testutil.ToFloat64(SafeSearchEnforcedHosts.WithLabelValues("safe.example")); got != 1 {
 		t.Fatalf("expected safe search host count 1, got %f", got)
@@ -75,17 +97,75 @@ func TestUpdateMetricsTracksSafeSearchSeparatelyFromBlockedQueries(t *testing.T)
 	if got := len(collector.topBlockedHosts.GetTop()); got != 0 {
 		t.Fatalf("expected safe search query not to be counted as blocked host, got %d hosts", got)
 	}
+	if got := testutil.ToFloat64(QueryFilteringReasons.WithLabelValues("filtered_safe_search")); got != 1 {
+		t.Fatalf("expected safe search reason count 1, got %f", got)
+	}
+}
+
+func TestUpdateMetricsDoesNotCountSafeBrowsingAsBlockedQuery(t *testing.T) {
+	resetMetricsForTest(t)
+	collector := NewMetricsCollector()
+
+	collector.UpdateMetrics(queryLogEntry("safebrowsing.example", "A", true, ReasonFilteredSafeBrowsing, 15_000_000, "8.8.8.8"))
+
+	if got := testutil.ToFloat64(BlockedQueries.Counter); got != 0 {
+		t.Fatalf("expected safe browsing not to increment blocked query count, got %f", got)
+	}
+	if got := len(collector.topHosts.GetTop()); got != 0 {
+		t.Fatalf("expected safe browsing query not to be counted as allowed host, got %d hosts", got)
+	}
+	if got := len(collector.topBlockedHosts.GetTop()); got != 0 {
+		t.Fatalf("expected safe browsing query not to be counted as blocked host, got %d hosts", got)
+	}
+	if got := testutil.ToFloat64(QueryFilteringReasons.WithLabelValues("filtered_safe_browsing")); got != 1 {
+		t.Fatalf("expected safe browsing reason count 1, got %f", got)
+	}
 }
 
 func TestUpdateMetricsExcludesUnknownUpstreamFromUpstreamAverages(t *testing.T) {
 	resetMetricsForTest(t)
 	collector := NewMetricsCollector()
 
-	collector.UpdateMetrics(queryLogEntry("unknown.example", "A", false, float64(0), 20_000_000, "unknown"))
-	collector.UpdateMetrics(queryLogEntry("empty.example", "A", false, float64(0), 30_000_000, ""))
+	collector.UpdateMetrics(queryLogEntry("unknown.example", "A", false, ReasonNotFilteredNotFound, 20_000_000, "unknown"))
+	collector.UpdateMetrics(queryLogEntry("empty.example", "A", false, ReasonNotFilteredNotFound, 30_000_000, ""))
 
 	if len(collector.upstreamResponseTimes) != 0 {
 		t.Fatalf("expected unknown upstreams to be excluded, got %#v", collector.upstreamResponseTimes)
+	}
+}
+
+func TestUpdateMetricsExcludesCachedQueriesFromUpstreamAverages(t *testing.T) {
+	resetMetricsForTest(t)
+	collector := NewMetricsCollector()
+
+	entry := queryLogEntry("cached.example", "A", false, ReasonNotFilteredNotFound, 20_000_000, "1.1.1.1")
+	entry.Cached = true
+	collector.UpdateMetrics(entry)
+
+	if len(collector.upstreamResponseTimes) != 0 {
+		t.Fatalf("expected cached query to be excluded from upstream averages, got %#v", collector.upstreamResponseTimes)
+	}
+	if got := testutil.ToFloat64(AverageResponseTime); got != 20 {
+		t.Fatalf("expected cached query to remain in overall response average, got %f", got)
+	}
+}
+
+func TestUpdateMetricsUsesQueryLogTimestampForRollingAverages(t *testing.T) {
+	resetMetricsForTest(t)
+	collector := NewMetricsCollector()
+	entry := queryLogEntry("old.example", "A", false, ReasonNotFilteredNotFound, 20_000_000, "1.1.1.1")
+	entry.Time = time.Now().Add(-10 * time.Minute)
+
+	collector.UpdateMetrics(entry)
+
+	if got := testutil.ToFloat64(DNSQueries.Counter); got != 1 {
+		t.Fatalf("expected old query to count toward total DNS queries, got %f", got)
+	}
+	if got := testutil.ToFloat64(AverageResponseTime); got != 0 {
+		t.Fatalf("expected old query not to affect rolling average, got %f", got)
+	}
+	if len(collector.responseTimes) != 0 {
+		t.Fatalf("expected old query to be pruned from response time window, got %#v", collector.responseTimes)
 	}
 }
 
@@ -201,17 +281,26 @@ func TestProcessMetricsSerializesTopHostResetAndAdd(t *testing.T) {
 	}
 }
 
-func queryLogEntry(host, queryType string, blocked bool, reason interface{}, elapsedNs float64, upstream string) map[string]interface{} {
-	return map[string]interface{}{
-		"QH":       host,
-		"QT":       queryType,
-		"Elapsed":  elapsedNs,
-		"Upstream": upstream,
-		"Result": map[string]interface{}{
-			"IsFiltered": blocked,
-			"Reason":     reason,
+func queryLogEntry(host, queryType string, blocked bool, reason FilteringReason, elapsedNs int64, upstream string) QueryLogEntry {
+	return QueryLogEntry{
+		Time:     time.Now(),
+		QHost:    host,
+		QType:    queryType,
+		Elapsed:  int64Ptr(elapsedNs),
+		Upstream: upstream,
+		Result: &QueryLogResult{
+			IsFiltered: blocked,
+			Reason:     filteringReasonPtr(reason),
 		},
 	}
+}
+
+func int64Ptr(value int64) *int64 {
+	return &value
+}
+
+func filteringReasonPtr(reason FilteringReason) *FilteringReason {
+	return &reason
 }
 
 func resetMetricsForTest(t *testing.T) {
@@ -223,6 +312,8 @@ func resetMetricsForTest(t *testing.T) {
 	oldTopQueryHosts := TopQueryHosts
 	oldTopBlockedQueryHosts := TopBlockedQueryHosts
 	oldSafeSearchEnforcedHosts := SafeSearchEnforcedHosts
+	oldQueryFilteringReasons := QueryFilteringReasons
+	oldQueryLogEntriesSkipped := QueryLogEntriesSkipped
 	oldAverageResponseTime := AverageResponseTime
 	oldAverageUpstreamResponseTime := AverageUpstreamResponseTime
 	t.Cleanup(func() {
@@ -232,6 +323,8 @@ func resetMetricsForTest(t *testing.T) {
 		TopQueryHosts = oldTopQueryHosts
 		TopBlockedQueryHosts = oldTopBlockedQueryHosts
 		SafeSearchEnforcedHosts = oldSafeSearchEnforcedHosts
+		QueryFilteringReasons = oldQueryFilteringReasons
+		QueryLogEntriesSkipped = oldQueryLogEntriesSkipped
 		AverageResponseTime = oldAverageResponseTime
 		AverageUpstreamResponseTime = oldAverageUpstreamResponseTime
 	})
@@ -260,6 +353,14 @@ func resetMetricsForTest(t *testing.T) {
 		Name: "agh_safe_search_enforced_hosts_total",
 		Help: "Safe search enforced hosts",
 	}, []string{"host"})
+	QueryFilteringReasons = NewCustomCounterVec(prometheus.CounterOpts{
+		Name: "agh_dns_filtering_reason_total",
+		Help: "DNS query filtering reasons",
+	}, []string{"reason"})
+	QueryLogEntriesSkipped = NewCustomCounterVec(prometheus.CounterOpts{
+		Name: "agh_querylog_entries_skipped_total",
+		Help: "Query log entries skipped by reason",
+	}, []string{"reason"})
 	AverageResponseTime = prometheus.NewGauge(prometheus.GaugeOpts{
 		Name: "agh_dns_average_response_time",
 		Help: "Average response time for DNS queries in milliseconds",

--- a/metrics/querylog_entry.go
+++ b/metrics/querylog_entry.go
@@ -1,0 +1,119 @@
+package metrics
+
+import "time"
+
+type FilteringReason int
+
+const (
+	ReasonNotFilteredNotFound FilteringReason = iota
+	ReasonNotFilteredAllowList
+	ReasonNotFilteredError
+	ReasonFilteredBlockList
+	ReasonFilteredSafeBrowsing
+	ReasonFilteredParental
+	ReasonFilteredInvalid
+	ReasonFilteredSafeSearch
+	ReasonFilteredBlockedService
+	ReasonRewritten
+	ReasonRewrittenAutoHosts
+	ReasonRewrittenRule
+)
+
+type QueryLogResult struct {
+	IsFiltered bool             `json:"IsFiltered"`
+	Reason     *FilteringReason `json:"Reason"`
+}
+
+type QueryLogEntry struct {
+	Time       time.Time `json:"T"`
+	LegacyTime time.Time `json:"Time"`
+	QHost      string    `json:"QH"`
+	QType      string    `json:"QT"`
+	QClass     string    `json:"QC"`
+	Upstream   string
+	Elapsed    *int64 `json:"Elapsed"`
+	Cached     bool   `json:"Cached,omitempty"`
+	Result     *QueryLogResult
+}
+
+func (e QueryLogEntry) Timestamp() time.Time {
+	if !e.Time.IsZero() {
+		return e.Time
+	}
+	return e.LegacyTime
+}
+
+func (e QueryLogEntry) SkipReason() string {
+	switch {
+	case e.Timestamp().IsZero():
+		return "missing_timestamp"
+	case e.QHost == "":
+		return "missing_query_host"
+	case e.QType == "":
+		return "missing_query_type"
+	case e.Elapsed == nil:
+		return "missing_elapsed"
+	case e.Result == nil:
+		return "missing_result"
+	case e.Result.IsFiltered && e.Result.Reason == nil:
+		return "missing_reason"
+	default:
+		return ""
+	}
+}
+
+func (e *QueryLogEntry) Normalize() {
+	if e.Upstream == "" {
+		e.Upstream = "unknown"
+	}
+	if e.Result != nil && !e.Result.IsFiltered && e.Result.Reason == nil {
+		reason := ReasonNotFilteredNotFound
+		e.Result.Reason = &reason
+	}
+}
+
+func (e QueryLogEntry) ElapsedMilliseconds() float64 {
+	if e.Elapsed == nil {
+		return 0
+	}
+	return float64(*e.Elapsed) / float64(time.Millisecond)
+}
+
+func (r FilteringReason) Label() string {
+	switch r {
+	case ReasonNotFilteredNotFound:
+		return "not_filtered_not_found"
+	case ReasonNotFilteredAllowList:
+		return "not_filtered_allow_list"
+	case ReasonNotFilteredError:
+		return "not_filtered_error"
+	case ReasonFilteredBlockList:
+		return "filtered_blocklist"
+	case ReasonFilteredSafeBrowsing:
+		return "filtered_safe_browsing"
+	case ReasonFilteredParental:
+		return "filtered_parental"
+	case ReasonFilteredInvalid:
+		return "filtered_invalid"
+	case ReasonFilteredSafeSearch:
+		return "filtered_safe_search"
+	case ReasonFilteredBlockedService:
+		return "filtered_blocked_service"
+	case ReasonRewritten:
+		return "rewritten"
+	case ReasonRewrittenAutoHosts:
+		return "rewritten_auto_hosts"
+	case ReasonRewrittenRule:
+		return "rewritten_rule"
+	default:
+		return "unknown"
+	}
+}
+
+func (r FilteringReason) IsBlocked() bool {
+	return r == ReasonFilteredBlockList || r == ReasonFilteredBlockedService
+}
+
+func (r FilteringReason) IsSafeSearch() bool {
+	return r == ReasonFilteredSafeSearch
+}


### PR DESCRIPTION
## Summary

- parse querylog records into a typed AdGuard-compatible subset with explicit skip reasons
- use querylog `T` timestamp, with legacy `Time` support, for rolling response windows
- align blocked/safesearch classification with AdGuard querylog reasons
- exclude cached responses from upstream-grouped timing while keeping the existing metric name
- load `querylog.json.1` before current `querylog.json` on startup
- add filtering reason and skipped-entry metrics

## Compatibility notes

- `agh_dns_average_upstream_response_time` keeps its existing name, but docs/help text clarify it is query processing time grouped by upstream from querylog `Elapsed`, not pure upstream RTT.
- `agh_blocked_dns_queries_total` now follows AdGuard blocked semantics: blocklist and blocked-service reasons. Safe browsing, parental, and safesearch remain represented through filtering reason metrics.

