### PR TITLE
Add Grafana dashboard fidelity updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,14 @@ The upstream timing metric keeps its historical name, but it is based on
 querylog `Elapsed` grouped by `Upstream`; AdGuard Home querylog records do not
 include pure upstream round-trip duration.
 
+## Grafana Dashboard
+
+The dashboard JSON is versioned in
+[dashboards/adguard-exporter.v2.json][dashboard-source]. It uses Grafana's V2
+JSON model, range-based counter queries for dashboard totals, filtering reason
+and skipped querylog record metrics, and upstream timing labeled as query
+processing time rather than pure upstream round-trip duration.
+
 ## How To Use This Container
 
 Configure AdGuard Home to dump query logs to disk at a regular interval by
@@ -289,3 +297,4 @@ spec:
 
 [dashboard-image]: assets/img/agh-grafana-dash.png
 [dashboard-link]: https://grafana.com/grafana/dashboards/21403
+[dashboard-source]: dashboards/adguard-exporter.v2.json

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ agh_dns_query_hosts_total: Top 100 DNS query hosts
 agh_blocked_dns_query_hosts_total: Top 100 blocked DNS query hosts
 agh_safe_search_enforced_hosts_total: Safe search enforced hosts
 agh_dns_filtering_reason_total: DNS query filtering reasons
+agh_dns_filtering_reason_hosts_total: Top 100 filtered hosts by reason
 agh_querylog_entries_skipped_total: Query log entries skipped by reason
 agh_dns_average_response_time: Average response time of all queries in ms
 agh_dns_average_upstream_response_time: Query processing time by upstream in ms

--- a/README.md
+++ b/README.md
@@ -18,12 +18,8 @@ sholdee/adguardexporter
 ghcr.io/sholdee/adguard-exporter
 ```
 
-Releases are created manually from the GitHub Actions `Publish` workflow. Enter
-a SemVer version such as `2.0.3` or `v2.0.3`; the workflow validates it, runs
-tests, creates the `vX.Y.Z` git tag, publishes multi-arch images, and creates a
-GitHub Release after the image manifests verify.
-
-Each release publishes these image tags:
+Published images support `linux/amd64` and `linux/arm64`. Releases publish
+these tags:
 
 ```text
 vX.Y.Z
@@ -34,12 +30,6 @@ latest
 
 The `latest` tag points to the latest release, not the latest commit on
 `master`.
-
-If a release run fails partway through, rerun the same workflow with the same
-version. The workflow can resume from a tag-only state or create a missing
-GitHub Release when the expected image tags already exist. If only some exact
-image tags exist, the workflow stops instead of overwriting SemVer tags; clean
-up the partial registry state manually before retrying.
 
 ## Available Metrics
 

--- a/dashboards/adguard-exporter.v2.json
+++ b/dashboards/adguard-exporter.v2.json
@@ -1,0 +1,1888 @@
+{
+  "annotations": [
+    {
+      "kind": "AnnotationQuery",
+      "spec": {
+        "builtIn": true,
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "query": {
+          "datasource": {
+            "name": "grafana"
+          },
+          "group": "grafana",
+          "kind": "DataQuery",
+          "spec": {},
+          "version": "v0"
+        }
+      }
+    }
+  ],
+  "cursorSync": "Off",
+  "description": "A dashboard for AdGuard DNS metrics.",
+  "editable": true,
+  "elements": {
+    "panel-2": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "$datasource"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "editorMode": "code",
+                      "expr": "sum(increase(agh_dns_queries_total{job=~\"$job\", namespace=~\"$namespace\", instance=~\"$instance\"}[$__range]))",
+                      "legendFormat": "Queries",
+                      "range": true
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "A"
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "",
+        "id": 2,
+        "links": [],
+        "title": "Queries In Range",
+        "vizConfig": {
+          "group": "stat",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "mappings": [],
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": 0
+                    }
+                  ]
+                },
+                "unit": "short"
+              },
+              "overrides": []
+            },
+            "options": {
+              "colorMode": "background",
+              "graphMode": "none",
+              "justifyMode": "auto",
+              "orientation": "auto",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": false
+              },
+              "showPercentChange": false,
+              "textMode": "auto",
+              "wideLayout": true,
+              "percentChangeColorMode": "standard"
+            }
+          },
+          "version": "13.0.1"
+        }
+      }
+    },
+    "panel-4": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "$datasource"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "editorMode": "code",
+                      "expr": "sum(increase(agh_blocked_dns_queries_total{job=~\"$job\", namespace=~\"$namespace\", instance=~\"$instance\"}[$__range]))",
+                      "legendFormat": "Blocked queries",
+                      "range": true
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "A"
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "",
+        "id": 4,
+        "links": [],
+        "title": "Blocked In Range",
+        "vizConfig": {
+          "group": "stat",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "mappings": [],
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": 0
+                    }
+                  ]
+                },
+                "unit": "short"
+              },
+              "overrides": []
+            },
+            "options": {
+              "colorMode": "background",
+              "graphMode": "none",
+              "justifyMode": "auto",
+              "orientation": "auto",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": false
+              },
+              "showPercentChange": false,
+              "textMode": "auto",
+              "wideLayout": true,
+              "percentChangeColorMode": "standard"
+            }
+          },
+          "version": "13.0.1"
+        }
+      }
+    },
+    "panel-5": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "$datasource"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "editorMode": "code",
+                      "expr": "sum(increase(agh_blocked_dns_queries_total{job=~\"$job\", namespace=~\"$namespace\", instance=~\"$instance\"}[$__range])) / clamp_min(sum(increase(agh_dns_queries_total{job=~\"$job\", namespace=~\"$namespace\", instance=~\"$instance\"}[$__range])), 1) * 100",
+                      "legendFormat": "Blocked percentage",
+                      "range": true
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "A"
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "Blocked means AdGuard blocklist or blocked-service reasons.",
+        "id": 5,
+        "links": [],
+        "title": "Blocked Percentage",
+        "vizConfig": {
+          "group": "stat",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "mappings": [],
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": 0
+                    },
+                    {
+                      "color": "orange",
+                      "value": 25
+                    },
+                    {
+                      "color": "red",
+                      "value": 50
+                    }
+                  ]
+                },
+                "unit": "percent"
+              },
+              "overrides": []
+            },
+            "options": {
+              "colorMode": "background",
+              "graphMode": "none",
+              "justifyMode": "auto",
+              "orientation": "auto",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": false
+              },
+              "showPercentChange": false,
+              "textMode": "auto",
+              "wideLayout": true,
+              "percentChangeColorMode": "standard"
+            }
+          },
+          "version": "13.0.1"
+        }
+      }
+    },
+    "panel-15": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "$datasource"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "editorMode": "code",
+                      "expr": "sum(increase(agh_querylog_entries_skipped_total{job=~\"$job\", namespace=~\"$namespace\", instance=~\"$instance\"}[$__range])) or vector(0)",
+                      "legendFormat": "Skipped records",
+                      "range": true
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "A"
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "Skipped records indicate invalid JSON or records missing fields required by the exporter.",
+        "id": 15,
+        "links": [],
+        "title": "Skipped Querylog Records",
+        "vizConfig": {
+          "group": "stat",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "mappings": [],
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": 0
+                    },
+                    {
+                      "color": "orange",
+                      "value": 1
+                    },
+                    {
+                      "color": "red",
+                      "value": 10
+                    }
+                  ]
+                },
+                "unit": "short"
+              },
+              "overrides": []
+            },
+            "options": {
+              "colorMode": "background",
+              "graphMode": "none",
+              "justifyMode": "auto",
+              "orientation": "auto",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": false
+              },
+              "showPercentChange": false,
+              "textMode": "auto",
+              "wideLayout": true,
+              "percentChangeColorMode": "standard"
+            }
+          },
+          "version": "13.0.1"
+        }
+      }
+    },
+    "panel-14": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "$datasource"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "editorMode": "code",
+                      "expr": "sum(rate(agh_dns_queries_total{job=~\"$job\", namespace=~\"$namespace\", instance=~\"$instance\"}[$__rate_interval]))",
+                      "legendFormat": "Queries per second",
+                      "range": true
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "A"
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "",
+        "id": 14,
+        "links": [],
+        "title": "Queries Per Second",
+        "vizConfig": {
+          "group": "timeseries",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "drawStyle": "line",
+                  "fillOpacity": 0,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 2,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "auto",
+                  "spanNulls": false,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "off"
+                  }
+                },
+                "mappings": [],
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": 0
+                    }
+                  ]
+                },
+                "unit": "reqps"
+              },
+              "overrides": []
+            },
+            "options": {
+              "legend": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "displayMode": "list",
+                "placement": "bottom",
+                "showLegend": true
+              },
+              "tooltip": {
+                "maxHeight": 600,
+                "mode": "single",
+                "sort": "none",
+                "hideZeros": false
+              },
+              "annotations": {
+                "clustering": -1,
+                "multiLane": false
+              }
+            }
+          },
+          "version": "13.0.1"
+        }
+      }
+    },
+    "panel-6": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "$datasource"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "editorMode": "code",
+                      "expr": "sum(rate(agh_blocked_dns_queries_total{job=~\"$job\", namespace=~\"$namespace\", instance=~\"$instance\"}[$__rate_interval])) / clamp_min(sum(rate(agh_dns_queries_total{job=~\"$job\", namespace=~\"$namespace\", instance=~\"$instance\"}[$__rate_interval])), 0.001) * 100",
+                      "legendFormat": "Blocked percentage",
+                      "range": true
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "A"
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "Blocked means AdGuard blocklist or blocked-service reasons.",
+        "id": 6,
+        "links": [],
+        "title": "Blocked Query Rate",
+        "vizConfig": {
+          "group": "timeseries",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "continuous-GrYlRd",
+                  "seriesBy": "last"
+                },
+                "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "drawStyle": "line",
+                  "fillOpacity": 15,
+                  "gradientMode": "scheme",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "smooth",
+                  "lineWidth": 2,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "auto",
+                  "spanNulls": false,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "off"
+                  }
+                },
+                "mappings": [],
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": 0
+                    },
+                    {
+                      "color": "red",
+                      "value": 80
+                    }
+                  ]
+                },
+                "unit": "percent"
+              },
+              "overrides": []
+            },
+            "options": {
+              "legend": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "displayMode": "list",
+                "placement": "bottom",
+                "showLegend": true
+              },
+              "tooltip": {
+                "maxHeight": 600,
+                "mode": "single",
+                "sort": "none",
+                "hideZeros": false
+              },
+              "annotations": {
+                "clustering": -1,
+                "multiLane": false
+              }
+            }
+          },
+          "version": "13.0.1"
+        }
+      }
+    },
+    "panel-10": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "$datasource"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "editorMode": "code",
+                      "expr": "sum by (query_type) (increase(agh_dns_query_types_total{job=~\"$job\", namespace=~\"$namespace\", instance=~\"$instance\"}[$__range]))",
+                      "legendFormat": "{{query_type}}",
+                      "range": true
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "A"
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "",
+        "id": 10,
+        "links": [],
+        "title": "Query Types",
+        "vizConfig": {
+          "group": "piechart",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  }
+                },
+                "mappings": [],
+                "unit": "short"
+              },
+              "overrides": []
+            },
+            "options": {
+              "displayLabels": [
+                "name"
+              ],
+              "legend": {
+                "displayMode": "table",
+                "placement": "right",
+                "showLegend": true,
+                "values": [
+                  "percent",
+                  "value"
+                ]
+              },
+              "pieType": "pie",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": false
+              },
+              "tooltip": {
+                "maxHeight": 600,
+                "mode": "single",
+                "sort": "none",
+                "hideZeros": false
+              },
+              "sort": "desc"
+            }
+          },
+          "version": "13.0.1"
+        }
+      }
+    },
+    "panel-16": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "$datasource"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "editorMode": "code",
+                      "expr": "sum by (reason) (increase(agh_dns_filtering_reason_total{job=~\"$job\", namespace=~\"$namespace\", instance=~\"$instance\"}[$__range]))",
+                      "legendFormat": "{{reason}}",
+                      "range": true
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "A"
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "AdGuard filtering result reasons as parsed from querylog Result.Reason.",
+        "id": 16,
+        "links": [],
+        "title": "Filtering Reasons",
+        "vizConfig": {
+          "group": "piechart",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  }
+                },
+                "mappings": [],
+                "unit": "short"
+              },
+              "overrides": []
+            },
+            "options": {
+              "displayLabels": [
+                "name"
+              ],
+              "legend": {
+                "displayMode": "table",
+                "placement": "right",
+                "showLegend": true,
+                "values": [
+                  "percent",
+                  "value"
+                ]
+              },
+              "pieType": "pie",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": false
+              },
+              "tooltip": {
+                "maxHeight": 600,
+                "mode": "single",
+                "sort": "none",
+                "hideZeros": false
+              },
+              "sort": "desc"
+            }
+          },
+          "version": "13.0.1"
+        }
+      }
+    },
+    "panel-12": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "$datasource"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "editorMode": "code",
+                      "expr": "avg(agh_dns_average_response_time{job=~\"$job\", namespace=~\"$namespace\", instance=~\"$instance\"})",
+                      "legendFormat": "Average response time",
+                      "range": true
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "A"
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "",
+        "id": 12,
+        "links": [],
+        "title": "Average Response Time",
+        "vizConfig": {
+          "group": "timeseries",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "drawStyle": "line",
+                  "fillOpacity": 0,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 2,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "auto",
+                  "spanNulls": false,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "off"
+                  }
+                },
+                "mappings": [],
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": 0
+                    },
+                    {
+                      "color": "red",
+                      "value": 100
+                    }
+                  ]
+                },
+                "unit": "ms"
+              },
+              "overrides": []
+            },
+            "options": {
+              "legend": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "displayMode": "list",
+                "placement": "bottom",
+                "showLegend": true
+              },
+              "tooltip": {
+                "maxHeight": 600,
+                "mode": "single",
+                "sort": "none",
+                "hideZeros": false
+              },
+              "annotations": {
+                "clustering": -1,
+                "multiLane": false
+              }
+            }
+          },
+          "version": "13.0.1"
+        }
+      }
+    },
+    "panel-13": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "$datasource"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "editorMode": "code",
+                      "expr": "avg by (server) (agh_dns_average_upstream_response_time{job=~\"$job\", namespace=~\"$namespace\", instance=~\"$instance\"})",
+                      "legendFormat": "{{server}}",
+                      "range": true
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "A"
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "This is querylog Elapsed grouped by upstream. AdGuard Home querylog records do not expose pure upstream round-trip duration, and cached queries are excluded.",
+        "id": 13,
+        "links": [],
+        "title": "Query Processing Time By Upstream",
+        "vizConfig": {
+          "group": "timeseries",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "drawStyle": "line",
+                  "fillOpacity": 0,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 2,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "auto",
+                  "spanNulls": false,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "off"
+                  }
+                },
+                "mappings": [],
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": 0
+                    },
+                    {
+                      "color": "red",
+                      "value": 100
+                    }
+                  ]
+                },
+                "unit": "ms"
+              },
+              "overrides": []
+            },
+            "options": {
+              "legend": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "displayMode": "list",
+                "placement": "bottom",
+                "showLegend": true
+              },
+              "tooltip": {
+                "maxHeight": 600,
+                "mode": "single",
+                "sort": "none",
+                "hideZeros": false
+              },
+              "annotations": {
+                "clustering": -1,
+                "multiLane": false
+              }
+            }
+          },
+          "version": "13.0.1"
+        }
+      }
+    },
+    "panel-17": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "$datasource"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "editorMode": "code",
+                      "expr": "sum by (reason) (rate(agh_querylog_entries_skipped_total{job=~\"$job\", namespace=~\"$namespace\", instance=~\"$instance\"}[$__rate_interval]))",
+                      "legendFormat": "{{reason}}",
+                      "range": true
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "A"
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "Skipped records should normally remain zero. Non-zero series point to invalid JSON or missing querylog fields.",
+        "id": 17,
+        "links": [],
+        "title": "Skipped Querylog Records By Reason",
+        "vizConfig": {
+          "group": "timeseries",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "drawStyle": "line",
+                  "fillOpacity": 0,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 2,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "auto",
+                  "spanNulls": false,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "off"
+                  }
+                },
+                "mappings": [],
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": 0
+                    },
+                    {
+                      "color": "red",
+                      "value": 1
+                    }
+                  ]
+                },
+                "unit": "ops"
+              },
+              "overrides": []
+            },
+            "options": {
+              "legend": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "displayMode": "list",
+                "placement": "bottom",
+                "showLegend": true
+              },
+              "tooltip": {
+                "maxHeight": 600,
+                "mode": "single",
+                "sort": "none",
+                "hideZeros": false
+              },
+              "annotations": {
+                "clustering": -1,
+                "multiLane": false
+              }
+            }
+          },
+          "version": "13.0.1"
+        }
+      }
+    },
+    "panel-7": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "$datasource"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "editorMode": "code",
+                      "expr": "topk(100, sum by (host) (agh_dns_query_hosts_total{job=~\"$job\", namespace=~\"$namespace\", instance=~\"$instance\"}) and on (host) (agh_dns_query_hosts_created{job=~\"$job\", namespace=~\"$namespace\", instance=~\"$instance\"} >= $metrics_start_time))",
+                      "format": "table",
+                      "instant": true,
+                      "legendFormat": "__auto",
+                      "range": false
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "A"
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": [
+              {
+                "group": "organize",
+                "kind": "Transformation",
+                "spec": {
+                  "options": {
+                    "excludeByName": {
+                      "Time": true,
+                      "__name__": true,
+                      "instance": true,
+                      "job": true,
+                      "namespace": true
+                    },
+                    "indexByName": {},
+                    "renameByName": {
+                      "Value": "Total queries",
+                      "host": "Host"
+                    }
+                  }
+                }
+              },
+              {
+                "group": "sortBy",
+                "kind": "Transformation",
+                "spec": {
+                  "options": {
+                    "fields": {},
+                    "sort": [
+                      {
+                        "desc": true,
+                        "field": "Total queries"
+                      }
+                    ]
+                  }
+                }
+              }
+            ]
+          }
+        },
+        "description": "",
+        "id": 7,
+        "links": [],
+        "title": "Top 100 Hosts",
+        "vizConfig": {
+          "group": "table",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "custom": {
+                  "align": "auto",
+                  "cellOptions": {
+                    "type": "auto"
+                  },
+                  "inspect": false,
+                  "footer": {
+                    "reducers": []
+                  }
+                },
+                "mappings": [],
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": 0
+                    }
+                  ]
+                },
+                "unit": "short"
+              },
+              "overrides": []
+            },
+            "options": {
+              "cellHeight": "sm",
+              "showHeader": true
+            }
+          },
+          "version": "13.0.1"
+        }
+      }
+    },
+    "panel-8": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "$datasource"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "editorMode": "code",
+                      "expr": "topk(100, sum by (host) (agh_blocked_dns_query_hosts_total{job=~\"$job\", namespace=~\"$namespace\", instance=~\"$instance\"}) and on (host) (agh_blocked_dns_query_hosts_created{job=~\"$job\", namespace=~\"$namespace\", instance=~\"$instance\"} >= $metrics_start_time))",
+                      "format": "table",
+                      "instant": true,
+                      "legendFormat": "__auto",
+                      "range": false
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "A"
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": [
+              {
+                "group": "organize",
+                "kind": "Transformation",
+                "spec": {
+                  "options": {
+                    "excludeByName": {
+                      "Time": true,
+                      "__name__": true,
+                      "instance": true,
+                      "job": true,
+                      "namespace": true
+                    },
+                    "indexByName": {},
+                    "renameByName": {
+                      "Value": "Total queries",
+                      "host": "Host"
+                    }
+                  }
+                }
+              },
+              {
+                "group": "sortBy",
+                "kind": "Transformation",
+                "spec": {
+                  "options": {
+                    "fields": {},
+                    "sort": [
+                      {
+                        "desc": true,
+                        "field": "Total queries"
+                      }
+                    ]
+                  }
+                }
+              }
+            ]
+          }
+        },
+        "description": "",
+        "id": 8,
+        "links": [],
+        "title": "Top 100 Blocked Hosts",
+        "vizConfig": {
+          "group": "table",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "custom": {
+                  "align": "auto",
+                  "cellOptions": {
+                    "type": "auto"
+                  },
+                  "inspect": false,
+                  "footer": {
+                    "reducers": []
+                  }
+                },
+                "mappings": [],
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": 0
+                    }
+                  ]
+                },
+                "unit": "short"
+              },
+              "overrides": []
+            },
+            "options": {
+              "cellHeight": "sm",
+              "showHeader": true
+            }
+          },
+          "version": "13.0.1"
+        }
+      }
+    },
+    "panel-11": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "$datasource"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "editorMode": "code",
+                      "expr": "topk(100, sum by (host) (agh_safe_search_enforced_hosts_total{job=~\"$job\", namespace=~\"$namespace\", instance=~\"$instance\"}) and on (host) (agh_safe_search_enforced_hosts_created{job=~\"$job\", namespace=~\"$namespace\", instance=~\"$instance\"} >= $metrics_start_time))",
+                      "format": "table",
+                      "instant": true,
+                      "legendFormat": "__auto",
+                      "range": false
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "A"
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": [
+              {
+                "group": "organize",
+                "kind": "Transformation",
+                "spec": {
+                  "options": {
+                    "excludeByName": {
+                      "Time": true,
+                      "__name__": true,
+                      "instance": true,
+                      "job": true,
+                      "namespace": true
+                    },
+                    "indexByName": {},
+                    "renameByName": {
+                      "Value": "Total queries",
+                      "host": "Host"
+                    }
+                  }
+                }
+              },
+              {
+                "group": "sortBy",
+                "kind": "Transformation",
+                "spec": {
+                  "options": {
+                    "fields": {},
+                    "sort": [
+                      {
+                        "desc": true,
+                        "field": "Total queries"
+                      }
+                    ]
+                  }
+                }
+              }
+            ]
+          }
+        },
+        "description": "",
+        "id": 11,
+        "links": [],
+        "title": "Safe Search Enforced Hosts",
+        "vizConfig": {
+          "group": "table",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "custom": {
+                  "align": "auto",
+                  "cellOptions": {
+                    "type": "auto"
+                  },
+                  "inspect": false,
+                  "footer": {
+                    "reducers": []
+                  }
+                },
+                "mappings": [],
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": 0
+                    }
+                  ]
+                },
+                "unit": "short"
+              },
+              "overrides": []
+            },
+            "options": {
+              "cellHeight": "sm",
+              "showHeader": true
+            }
+          },
+          "version": "13.0.1"
+        }
+      }
+    }
+  },
+  "layout": {
+    "kind": "GridLayout",
+    "spec": {
+      "items": [
+        {
+          "kind": "GridLayoutItem",
+          "spec": {
+            "element": {
+              "kind": "ElementReference",
+              "name": "panel-2"
+            },
+            "height": 4,
+            "width": 6,
+            "x": 0,
+            "y": 0
+          }
+        },
+        {
+          "kind": "GridLayoutItem",
+          "spec": {
+            "element": {
+              "kind": "ElementReference",
+              "name": "panel-4"
+            },
+            "height": 4,
+            "width": 6,
+            "x": 6,
+            "y": 0
+          }
+        },
+        {
+          "kind": "GridLayoutItem",
+          "spec": {
+            "element": {
+              "kind": "ElementReference",
+              "name": "panel-5"
+            },
+            "height": 4,
+            "width": 6,
+            "x": 12,
+            "y": 0
+          }
+        },
+        {
+          "kind": "GridLayoutItem",
+          "spec": {
+            "element": {
+              "kind": "ElementReference",
+              "name": "panel-15"
+            },
+            "height": 4,
+            "width": 6,
+            "x": 18,
+            "y": 0
+          }
+        },
+        {
+          "kind": "GridLayoutItem",
+          "spec": {
+            "element": {
+              "kind": "ElementReference",
+              "name": "panel-14"
+            },
+            "height": 8,
+            "width": 12,
+            "x": 0,
+            "y": 4
+          }
+        },
+        {
+          "kind": "GridLayoutItem",
+          "spec": {
+            "element": {
+              "kind": "ElementReference",
+              "name": "panel-6"
+            },
+            "height": 8,
+            "width": 12,
+            "x": 12,
+            "y": 4
+          }
+        },
+        {
+          "kind": "GridLayoutItem",
+          "spec": {
+            "element": {
+              "kind": "ElementReference",
+              "name": "panel-10"
+            },
+            "height": 8,
+            "width": 8,
+            "x": 0,
+            "y": 12
+          }
+        },
+        {
+          "kind": "GridLayoutItem",
+          "spec": {
+            "element": {
+              "kind": "ElementReference",
+              "name": "panel-16"
+            },
+            "height": 8,
+            "width": 8,
+            "x": 8,
+            "y": 12
+          }
+        },
+        {
+          "kind": "GridLayoutItem",
+          "spec": {
+            "element": {
+              "kind": "ElementReference",
+              "name": "panel-12"
+            },
+            "height": 8,
+            "width": 8,
+            "x": 16,
+            "y": 12
+          }
+        },
+        {
+          "kind": "GridLayoutItem",
+          "spec": {
+            "element": {
+              "kind": "ElementReference",
+              "name": "panel-13"
+            },
+            "height": 8,
+            "width": 12,
+            "x": 0,
+            "y": 20
+          }
+        },
+        {
+          "kind": "GridLayoutItem",
+          "spec": {
+            "element": {
+              "kind": "ElementReference",
+              "name": "panel-17"
+            },
+            "height": 8,
+            "width": 12,
+            "x": 12,
+            "y": 20
+          }
+        },
+        {
+          "kind": "GridLayoutItem",
+          "spec": {
+            "element": {
+              "kind": "ElementReference",
+              "name": "panel-7"
+            },
+            "height": 15,
+            "width": 8,
+            "x": 0,
+            "y": 28
+          }
+        },
+        {
+          "kind": "GridLayoutItem",
+          "spec": {
+            "element": {
+              "kind": "ElementReference",
+              "name": "panel-8"
+            },
+            "height": 15,
+            "width": 8,
+            "x": 8,
+            "y": 28
+          }
+        },
+        {
+          "kind": "GridLayoutItem",
+          "spec": {
+            "element": {
+              "kind": "ElementReference",
+              "name": "panel-11"
+            },
+            "height": 15,
+            "width": 8,
+            "x": 16,
+            "y": 28
+          }
+        }
+      ]
+    }
+  },
+  "links": [
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": false,
+      "keepTime": false,
+      "tags": [],
+      "targetBlank": true,
+      "title": "Exporter repository",
+      "tooltip": "",
+      "type": "link",
+      "url": "https://github.com/sholdee/adguard-exporter"
+    }
+  ],
+  "liveNow": false,
+  "preload": false,
+  "tags": [
+    "dns",
+    "adguard"
+  ],
+  "timeSettings": {
+    "autoRefresh": "10s",
+    "autoRefreshIntervals": [
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "fiscalYearStartMonth": 0,
+    "from": "now-3h",
+    "hideTimepicker": false,
+    "timezone": "utc",
+    "to": "now"
+  },
+  "title": "AdGuard DNS Metrics",
+  "variables": [
+    {
+      "kind": "DatasourceVariable",
+      "spec": {
+        "allowCustomValue": true,
+        "current": {
+          "text": "Prometheus",
+          "value": "prometheus"
+        },
+        "hide": "dontHide",
+        "includeAll": false,
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "pluginId": "prometheus",
+        "refresh": "onDashboardLoad",
+        "regex": "",
+        "skipUrlSync": false
+      }
+    },
+    {
+      "kind": "QueryVariable",
+      "spec": {
+        "allowCustomValue": true,
+        "current": {
+          "text": "All",
+          "value": [
+            "$__all"
+          ]
+        },
+        "definition": "label_values(agh_dns_queries_total, job)",
+        "hide": "dontHide",
+        "includeAll": true,
+        "multi": true,
+        "name": "job",
+        "options": [],
+        "query": {
+          "datasource": {
+            "name": "Prometheus"
+          },
+          "group": "prometheus",
+          "kind": "DataQuery",
+          "spec": {
+            "qryType": 1,
+            "query": "label_values(agh_dns_queries_total, job)",
+            "refId": "PrometheusVariableQueryEditor-Job"
+          },
+          "version": "v0"
+        },
+        "refresh": "onTimeRangeChanged",
+        "regex": "",
+        "regexApplyTo": "value",
+        "skipUrlSync": false,
+        "sort": "alphabeticalAsc",
+        "allValue": ".*"
+      }
+    },
+    {
+      "kind": "QueryVariable",
+      "spec": {
+        "allowCustomValue": true,
+        "current": {
+          "text": "All",
+          "value": [
+            "$__all"
+          ]
+        },
+        "definition": "label_values(agh_dns_queries_total{job=~\"$job\"}, namespace)",
+        "hide": "dontHide",
+        "includeAll": true,
+        "multi": true,
+        "name": "namespace",
+        "options": [],
+        "query": {
+          "datasource": {
+            "name": "Prometheus"
+          },
+          "group": "prometheus",
+          "kind": "DataQuery",
+          "spec": {
+            "qryType": 1,
+            "query": "label_values(agh_dns_queries_total{job=~\"$job\"}, namespace)",
+            "refId": "PrometheusVariableQueryEditor-Namespace"
+          },
+          "version": "v0"
+        },
+        "refresh": "onTimeRangeChanged",
+        "regex": "",
+        "regexApplyTo": "value",
+        "skipUrlSync": false,
+        "sort": "alphabeticalAsc",
+        "allValue": ".*"
+      }
+    },
+    {
+      "kind": "QueryVariable",
+      "spec": {
+        "allowCustomValue": true,
+        "current": {
+          "text": "All",
+          "value": [
+            "$__all"
+          ]
+        },
+        "definition": "label_values(agh_dns_queries_total{job=~\"$job\", namespace=~\"$namespace\"}, instance)",
+        "hide": "dontHide",
+        "includeAll": true,
+        "multi": true,
+        "name": "instance",
+        "options": [],
+        "query": {
+          "datasource": {
+            "name": "Prometheus"
+          },
+          "group": "prometheus",
+          "kind": "DataQuery",
+          "spec": {
+            "qryType": 1,
+            "query": "label_values(agh_dns_queries_total{job=~\"$job\", namespace=~\"$namespace\"}, instance)",
+            "refId": "PrometheusVariableQueryEditor-Instance"
+          },
+          "version": "v0"
+        },
+        "refresh": "onTimeRangeChanged",
+        "regex": "",
+        "regexApplyTo": "value",
+        "skipUrlSync": false,
+        "sort": "alphabeticalAsc",
+        "allValue": ".*"
+      }
+    },
+    {
+      "kind": "QueryVariable",
+      "spec": {
+        "allowCustomValue": true,
+        "current": {
+          "text": "",
+          "value": ""
+        },
+        "definition": "query_result(scalar(min(agh_dns_queries_created{job=~\"$job\", namespace=~\"$namespace\", instance=~\"$instance\"})))",
+        "hide": "hideVariable",
+        "includeAll": false,
+        "multi": false,
+        "name": "metrics_start_time",
+        "options": [],
+        "query": {
+          "datasource": {
+            "name": "Prometheus"
+          },
+          "group": "prometheus",
+          "kind": "DataQuery",
+          "spec": {
+            "qryType": 3,
+            "query": "query_result(scalar(min(agh_dns_queries_created{job=~\"$job\", namespace=~\"$namespace\", instance=~\"$instance\"})))",
+            "refId": "PrometheusVariableQueryEditor-MetricsStartTime"
+          },
+          "version": "v0"
+        },
+        "refresh": "onTimeRangeChanged",
+        "regex": "",
+        "regexApplyTo": "value",
+        "skipUrlSync": false,
+        "sort": "disabled"
+      }
+    }
+  ]
+}

--- a/dashboards/adguard-exporter.v2.json
+++ b/dashboards/adguard-exporter.v2.json
@@ -24,579 +24,6 @@
   "description": "A dashboard for AdGuard DNS metrics.",
   "editable": true,
   "elements": {
-    "panel-2": {
-      "kind": "Panel",
-      "spec": {
-        "data": {
-          "kind": "QueryGroup",
-          "spec": {
-            "queries": [
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "$datasource"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "editorMode": "code",
-                      "expr": "sum(increase(agh_dns_queries_total{job=~\"$job\", namespace=~\"$namespace\", instance=~\"$instance\"}[$__range]))",
-                      "legendFormat": "Queries",
-                      "range": true
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "A"
-                }
-              }
-            ],
-            "queryOptions": {},
-            "transformations": []
-          }
-        },
-        "description": "",
-        "id": 2,
-        "links": [],
-        "title": "Queries In Range",
-        "vizConfig": {
-          "group": "stat",
-          "kind": "VizConfig",
-          "spec": {
-            "fieldConfig": {
-              "defaults": {
-                "mappings": [],
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green",
-                      "value": 0
-                    }
-                  ]
-                },
-                "unit": "short"
-              },
-              "overrides": []
-            },
-            "options": {
-              "colorMode": "background",
-              "graphMode": "none",
-              "justifyMode": "auto",
-              "orientation": "auto",
-              "reduceOptions": {
-                "calcs": [
-                  "lastNotNull"
-                ],
-                "fields": "",
-                "values": false
-              },
-              "showPercentChange": false,
-              "textMode": "auto",
-              "wideLayout": true,
-              "percentChangeColorMode": "standard"
-            }
-          },
-          "version": "13.0.1"
-        }
-      }
-    },
-    "panel-4": {
-      "kind": "Panel",
-      "spec": {
-        "data": {
-          "kind": "QueryGroup",
-          "spec": {
-            "queries": [
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "$datasource"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "editorMode": "code",
-                      "expr": "sum(increase(agh_blocked_dns_queries_total{job=~\"$job\", namespace=~\"$namespace\", instance=~\"$instance\"}[$__range]))",
-                      "legendFormat": "Blocked queries",
-                      "range": true
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "A"
-                }
-              }
-            ],
-            "queryOptions": {},
-            "transformations": []
-          }
-        },
-        "description": "",
-        "id": 4,
-        "links": [],
-        "title": "Blocked In Range",
-        "vizConfig": {
-          "group": "stat",
-          "kind": "VizConfig",
-          "spec": {
-            "fieldConfig": {
-              "defaults": {
-                "mappings": [],
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green",
-                      "value": 0
-                    }
-                  ]
-                },
-                "unit": "short"
-              },
-              "overrides": []
-            },
-            "options": {
-              "colorMode": "background",
-              "graphMode": "none",
-              "justifyMode": "auto",
-              "orientation": "auto",
-              "reduceOptions": {
-                "calcs": [
-                  "lastNotNull"
-                ],
-                "fields": "",
-                "values": false
-              },
-              "showPercentChange": false,
-              "textMode": "auto",
-              "wideLayout": true,
-              "percentChangeColorMode": "standard"
-            }
-          },
-          "version": "13.0.1"
-        }
-      }
-    },
-    "panel-5": {
-      "kind": "Panel",
-      "spec": {
-        "data": {
-          "kind": "QueryGroup",
-          "spec": {
-            "queries": [
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "$datasource"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "editorMode": "code",
-                      "expr": "sum(increase(agh_blocked_dns_queries_total{job=~\"$job\", namespace=~\"$namespace\", instance=~\"$instance\"}[$__range])) / clamp_min(sum(increase(agh_dns_queries_total{job=~\"$job\", namespace=~\"$namespace\", instance=~\"$instance\"}[$__range])), 1) * 100",
-                      "legendFormat": "Blocked percentage",
-                      "range": true
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "A"
-                }
-              }
-            ],
-            "queryOptions": {},
-            "transformations": []
-          }
-        },
-        "description": "Blocked means AdGuard blocklist or blocked-service reasons.",
-        "id": 5,
-        "links": [],
-        "title": "Blocked Percentage",
-        "vizConfig": {
-          "group": "stat",
-          "kind": "VizConfig",
-          "spec": {
-            "fieldConfig": {
-              "defaults": {
-                "mappings": [],
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green",
-                      "value": 0
-                    },
-                    {
-                      "color": "orange",
-                      "value": 25
-                    },
-                    {
-                      "color": "red",
-                      "value": 50
-                    }
-                  ]
-                },
-                "unit": "percent"
-              },
-              "overrides": []
-            },
-            "options": {
-              "colorMode": "background",
-              "graphMode": "none",
-              "justifyMode": "auto",
-              "orientation": "auto",
-              "reduceOptions": {
-                "calcs": [
-                  "lastNotNull"
-                ],
-                "fields": "",
-                "values": false
-              },
-              "showPercentChange": false,
-              "textMode": "auto",
-              "wideLayout": true,
-              "percentChangeColorMode": "standard"
-            }
-          },
-          "version": "13.0.1"
-        }
-      }
-    },
-    "panel-15": {
-      "kind": "Panel",
-      "spec": {
-        "data": {
-          "kind": "QueryGroup",
-          "spec": {
-            "queries": [
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "$datasource"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "editorMode": "code",
-                      "expr": "sum(increase(agh_querylog_entries_skipped_total{job=~\"$job\", namespace=~\"$namespace\", instance=~\"$instance\"}[$__range])) or vector(0)",
-                      "legendFormat": "Skipped records",
-                      "range": true
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "A"
-                }
-              }
-            ],
-            "queryOptions": {},
-            "transformations": []
-          }
-        },
-        "description": "Skipped records indicate invalid JSON or records missing fields required by the exporter.",
-        "id": 15,
-        "links": [],
-        "title": "Skipped Querylog Records",
-        "vizConfig": {
-          "group": "stat",
-          "kind": "VizConfig",
-          "spec": {
-            "fieldConfig": {
-              "defaults": {
-                "mappings": [],
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green",
-                      "value": 0
-                    },
-                    {
-                      "color": "orange",
-                      "value": 1
-                    },
-                    {
-                      "color": "red",
-                      "value": 10
-                    }
-                  ]
-                },
-                "unit": "short"
-              },
-              "overrides": []
-            },
-            "options": {
-              "colorMode": "background",
-              "graphMode": "none",
-              "justifyMode": "auto",
-              "orientation": "auto",
-              "reduceOptions": {
-                "calcs": [
-                  "lastNotNull"
-                ],
-                "fields": "",
-                "values": false
-              },
-              "showPercentChange": false,
-              "textMode": "auto",
-              "wideLayout": true,
-              "percentChangeColorMode": "standard"
-            }
-          },
-          "version": "13.0.1"
-        }
-      }
-    },
-    "panel-14": {
-      "kind": "Panel",
-      "spec": {
-        "data": {
-          "kind": "QueryGroup",
-          "spec": {
-            "queries": [
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "$datasource"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "editorMode": "code",
-                      "expr": "sum(rate(agh_dns_queries_total{job=~\"$job\", namespace=~\"$namespace\", instance=~\"$instance\"}[$__rate_interval]))",
-                      "legendFormat": "Queries per second",
-                      "range": true
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "A"
-                }
-              }
-            ],
-            "queryOptions": {},
-            "transformations": []
-          }
-        },
-        "description": "",
-        "id": 14,
-        "links": [],
-        "title": "Queries Per Second",
-        "vizConfig": {
-          "group": "timeseries",
-          "kind": "VizConfig",
-          "spec": {
-            "fieldConfig": {
-              "defaults": {
-                "color": {
-                  "mode": "palette-classic"
-                },
-                "custom": {
-                  "axisBorderShow": false,
-                  "axisCenteredZero": false,
-                  "axisColorMode": "text",
-                  "axisLabel": "",
-                  "axisPlacement": "auto",
-                  "barAlignment": 0,
-                  "drawStyle": "line",
-                  "fillOpacity": 0,
-                  "gradientMode": "none",
-                  "hideFrom": {
-                    "legend": false,
-                    "tooltip": false,
-                    "viz": false
-                  },
-                  "insertNulls": false,
-                  "lineInterpolation": "linear",
-                  "lineWidth": 2,
-                  "pointSize": 5,
-                  "scaleDistribution": {
-                    "type": "linear"
-                  },
-                  "showPoints": "auto",
-                  "spanNulls": false,
-                  "stacking": {
-                    "group": "A",
-                    "mode": "none"
-                  },
-                  "thresholdsStyle": {
-                    "mode": "off"
-                  }
-                },
-                "mappings": [],
-                "min": 0,
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green",
-                      "value": 0
-                    }
-                  ]
-                },
-                "unit": "reqps"
-              },
-              "overrides": []
-            },
-            "options": {
-              "legend": {
-                "calcs": [
-                  "lastNotNull"
-                ],
-                "displayMode": "list",
-                "placement": "bottom",
-                "showLegend": true
-              },
-              "tooltip": {
-                "maxHeight": 600,
-                "mode": "single",
-                "sort": "none",
-                "hideZeros": false
-              },
-              "annotations": {
-                "clustering": -1,
-                "multiLane": false
-              }
-            }
-          },
-          "version": "13.0.1"
-        }
-      }
-    },
-    "panel-6": {
-      "kind": "Panel",
-      "spec": {
-        "data": {
-          "kind": "QueryGroup",
-          "spec": {
-            "queries": [
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "$datasource"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "editorMode": "code",
-                      "expr": "sum(rate(agh_blocked_dns_queries_total{job=~\"$job\", namespace=~\"$namespace\", instance=~\"$instance\"}[$__rate_interval])) / clamp_min(sum(rate(agh_dns_queries_total{job=~\"$job\", namespace=~\"$namespace\", instance=~\"$instance\"}[$__rate_interval])), 0.001) * 100",
-                      "legendFormat": "Blocked percentage",
-                      "range": true
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "A"
-                }
-              }
-            ],
-            "queryOptions": {},
-            "transformations": []
-          }
-        },
-        "description": "Blocked means AdGuard blocklist or blocked-service reasons.",
-        "id": 6,
-        "links": [],
-        "title": "Blocked Query Rate",
-        "vizConfig": {
-          "group": "timeseries",
-          "kind": "VizConfig",
-          "spec": {
-            "fieldConfig": {
-              "defaults": {
-                "color": {
-                  "mode": "continuous-GrYlRd",
-                  "seriesBy": "last"
-                },
-                "custom": {
-                  "axisBorderShow": false,
-                  "axisCenteredZero": false,
-                  "axisColorMode": "text",
-                  "axisLabel": "",
-                  "axisPlacement": "auto",
-                  "barAlignment": 0,
-                  "drawStyle": "line",
-                  "fillOpacity": 15,
-                  "gradientMode": "scheme",
-                  "hideFrom": {
-                    "legend": false,
-                    "tooltip": false,
-                    "viz": false
-                  },
-                  "insertNulls": false,
-                  "lineInterpolation": "smooth",
-                  "lineWidth": 2,
-                  "pointSize": 5,
-                  "scaleDistribution": {
-                    "type": "linear"
-                  },
-                  "showPoints": "auto",
-                  "spanNulls": false,
-                  "stacking": {
-                    "group": "A",
-                    "mode": "none"
-                  },
-                  "thresholdsStyle": {
-                    "mode": "off"
-                  }
-                },
-                "mappings": [],
-                "min": 0,
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green",
-                      "value": 0
-                    },
-                    {
-                      "color": "red",
-                      "value": 80
-                    }
-                  ]
-                },
-                "unit": "percent"
-              },
-              "overrides": []
-            },
-            "options": {
-              "legend": {
-                "calcs": [
-                  "lastNotNull"
-                ],
-                "displayMode": "list",
-                "placement": "bottom",
-                "showLegend": true
-              },
-              "tooltip": {
-                "maxHeight": 600,
-                "mode": "single",
-                "sort": "none",
-                "hideZeros": false
-              },
-              "annotations": {
-                "clustering": -1,
-                "multiLane": false
-              }
-            }
-          },
-          "version": "13.0.1"
-        }
-      }
-    },
     "panel-10": {
       "kind": "Panel",
       "spec": {
@@ -630,7 +57,7 @@
             "transformations": []
           }
         },
-        "description": "",
+        "description": "Query volume by DNS record type during the selected dashboard time range.",
         "id": 10,
         "links": [],
         "title": "Query Types",
@@ -650,7 +77,6 @@
                     "viz": false
                   }
                 },
-                "mappings": [],
                 "unit": "short"
               },
               "overrides": []
@@ -676,20 +102,20 @@
                 "fields": "",
                 "values": false
               },
+              "sort": "desc",
               "tooltip": {
+                "hideZeros": false,
                 "maxHeight": 600,
                 "mode": "single",
-                "sort": "none",
-                "hideZeros": false
-              },
-              "sort": "desc"
+                "sort": "none"
+              }
             }
           },
           "version": "13.0.1"
         }
       }
     },
-    "panel-16": {
+    "panel-11": {
       "kind": "Panel",
       "spec": {
         "data": {
@@ -708,9 +134,11 @@
                     "kind": "DataQuery",
                     "spec": {
                       "editorMode": "code",
-                      "expr": "sum by (reason) (increase(agh_dns_filtering_reason_total{job=~\"$job\", namespace=~\"$namespace\", instance=~\"$instance\"}[$__range]))",
-                      "legendFormat": "{{reason}}",
-                      "range": true
+                      "expr": "topk(100, sum by (host, reason) (agh_dns_filtering_reason_hosts_total{job=~\"$job\", namespace=~\"$namespace\", instance=~\"$instance\"}) and on (host, reason) (agh_dns_filtering_reason_hosts_created{job=~\"$job\", namespace=~\"$namespace\", instance=~\"$instance\"} >= $metrics_start_time))",
+                      "format": "table",
+                      "instant": true,
+                      "legendFormat": "__auto",
+                      "range": false
                     },
                     "version": "v0"
                   },
@@ -719,62 +147,88 @@
               }
             ],
             "queryOptions": {},
-            "transformations": []
+            "transformations": [
+              {
+                "group": "organize",
+                "kind": "Transformation",
+                "spec": {
+                  "options": {
+                    "excludeByName": {
+                      "Time": true,
+                      "__name__": true,
+                      "instance": true,
+                      "job": true,
+                      "namespace": true
+                    },
+                    "indexByName": {},
+                    "renameByName": {
+                      "Value": "Total queries",
+                      "host": "Host",
+                      "reason": "Reason"
+                    }
+                  }
+                }
+              },
+              {
+                "group": "sortBy",
+                "kind": "Transformation",
+                "spec": {
+                  "options": {
+                    "fields": {},
+                    "sort": [
+                      {
+                        "desc": true,
+                        "field": "Total queries"
+                      }
+                    ]
+                  }
+                }
+              }
+            ]
           }
         },
-        "description": "AdGuard filtering result reasons as parsed from querylog Result.Reason.",
-        "id": 16,
+        "description": "Current top filtered hosts grouped by AdGuard filtering reason. Includes blocklist, blocked-service, safe-search, safe-browsing, parental, and invalid filtered outcomes; allowed and rewritten queries are excluded.",
+        "id": 11,
         "links": [],
-        "title": "Filtering Reasons",
+        "title": "Top Filtered Hosts",
         "vizConfig": {
-          "group": "piechart",
+          "group": "table",
           "kind": "VizConfig",
           "spec": {
             "fieldConfig": {
               "defaults": {
-                "color": {
-                  "mode": "palette-classic"
-                },
                 "custom": {
-                  "hideFrom": {
-                    "legend": false,
-                    "tooltip": false,
-                    "viz": false
-                  }
+                  "align": "auto",
+                  "cellOptions": {
+                    "type": "auto"
+                  },
+                  "footer": {
+                    "reducers": []
+                  },
+                  "inspect": false
                 },
-                "mappings": [],
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": 0
+                    }
+                  ]
+                },
                 "unit": "short"
               },
               "overrides": []
             },
             "options": {
-              "displayLabels": [
-                "name"
-              ],
-              "legend": {
-                "displayMode": "table",
-                "placement": "right",
-                "showLegend": true,
-                "values": [
-                  "percent",
-                  "value"
-                ]
-              },
-              "pieType": "pie",
-              "reduceOptions": {
-                "calcs": [
-                  "lastNotNull"
-                ],
-                "fields": "",
-                "values": false
-              },
-              "tooltip": {
-                "maxHeight": 600,
-                "mode": "single",
-                "sort": "none",
-                "hideZeros": false
-              },
-              "sort": "desc"
+              "cellHeight": "sm",
+              "showHeader": true,
+              "sortBy": [
+                {
+                  "desc": true,
+                  "displayName": "Total queries"
+                }
+              ]
             }
           },
           "version": "13.0.1"
@@ -814,7 +268,7 @@
             "transformations": []
           }
         },
-        "description": "",
+        "description": "Five-minute rolling average of querylog Elapsed across all valid records, including cached, blocked, rewritten, and upstream-routed queries.",
         "id": 12,
         "links": [],
         "title": "Average Response Time",
@@ -834,6 +288,7 @@
                   "axisLabel": "",
                   "axisPlacement": "auto",
                   "barAlignment": 0,
+                  "barWidthFactor": 0.6,
                   "drawStyle": "line",
                   "fillOpacity": 0,
                   "gradientMode": "none",
@@ -850,6 +305,7 @@
                     "type": "linear"
                   },
                   "showPoints": "auto",
+                  "showValues": false,
                   "spanNulls": false,
                   "stacking": {
                     "group": "A",
@@ -859,7 +315,6 @@
                     "mode": "off"
                   }
                 },
-                "mappings": [],
                 "min": 0,
                 "thresholds": {
                   "mode": "absolute",
@@ -876,9 +331,38 @@
                 },
                 "unit": "ms"
               },
-              "overrides": []
+              "overrides": [
+                {
+                  "__systemRef": "hideSeriesFrom",
+                  "matcher": {
+                    "id": "byNames",
+                    "options": {
+                      "mode": "exclude",
+                      "names": [
+                        "Average response time"
+                      ],
+                      "prefix": "All except:",
+                      "readOnly": true
+                    }
+                  },
+                  "properties": [
+                    {
+                      "id": "custom.hideFrom",
+                      "value": {
+                        "legend": false,
+                        "tooltip": true,
+                        "viz": true
+                      }
+                    }
+                  ]
+                }
+              ]
             },
             "options": {
+              "annotations": {
+                "clustering": -1,
+                "multiLane": false
+              },
               "legend": {
                 "calcs": [
                   "lastNotNull"
@@ -888,14 +372,10 @@
                 "showLegend": true
               },
               "tooltip": {
+                "hideZeros": false,
                 "maxHeight": 600,
                 "mode": "single",
-                "sort": "none",
-                "hideZeros": false
-              },
-              "annotations": {
-                "clustering": -1,
-                "multiLane": false
+                "sort": "none"
               }
             }
           },
@@ -956,6 +436,7 @@
                   "axisLabel": "",
                   "axisPlacement": "auto",
                   "barAlignment": 0,
+                  "barWidthFactor": 0.6,
                   "drawStyle": "line",
                   "fillOpacity": 0,
                   "gradientMode": "none",
@@ -972,6 +453,7 @@
                     "type": "linear"
                   },
                   "showPoints": "auto",
+                  "showValues": false,
                   "spanNulls": false,
                   "stacking": {
                     "group": "A",
@@ -981,7 +463,6 @@
                     "mode": "off"
                   }
                 },
-                "mappings": [],
                 "min": 0,
                 "thresholds": {
                   "mode": "absolute",
@@ -1001,6 +482,10 @@
               "overrides": []
             },
             "options": {
+              "annotations": {
+                "clustering": -1,
+                "multiLane": false
+              },
               "legend": {
                 "calcs": [
                   "lastNotNull"
@@ -1010,14 +495,306 @@
                 "showLegend": true
               },
               "tooltip": {
+                "hideZeros": false,
                 "maxHeight": 600,
                 "mode": "single",
-                "sort": "none",
-                "hideZeros": false
+                "sort": "none"
+              }
+            }
+          },
+          "version": "13.0.1"
+        }
+      }
+    },
+    "panel-14": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "$datasource"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "editorMode": "code",
+                      "expr": "sum(rate(agh_dns_queries_total{job=~\"$job\", namespace=~\"$namespace\", instance=~\"$instance\"}[$__rate_interval]))",
+                      "legendFormat": "Queries per second",
+                      "range": true
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "A"
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "Rate of valid querylog entries processed by the exporter, aggregated across the selected instances.",
+        "id": 14,
+        "links": [],
+        "title": "Queries Per Second",
+        "vizConfig": {
+          "group": "timeseries",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "barWidthFactor": 0.6,
+                  "drawStyle": "line",
+                  "fillOpacity": 0,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 2,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "auto",
+                  "showValues": false,
+                  "spanNulls": false,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "off"
+                  }
+                },
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": 0
+                    }
+                  ]
+                },
+                "unit": "reqps"
               },
+              "overrides": []
+            },
+            "options": {
               "annotations": {
                 "clustering": -1,
                 "multiLane": false
+              },
+              "legend": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "displayMode": "list",
+                "placement": "bottom",
+                "showLegend": true
+              },
+              "tooltip": {
+                "hideZeros": false,
+                "maxHeight": 600,
+                "mode": "single",
+                "sort": "none"
+              }
+            }
+          },
+          "version": "13.0.1"
+        }
+      }
+    },
+    "panel-15": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "$datasource"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "editorMode": "code",
+                      "expr": "sum(increase(agh_querylog_entries_skipped_total{job=~\"$job\", namespace=~\"$namespace\", instance=~\"$instance\"}[$__range])) or vector(0)",
+                      "legendFormat": "Skipped records",
+                      "range": true
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "A"
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "Skipped records indicate invalid JSON or records missing fields required by the exporter.",
+        "id": 15,
+        "links": [],
+        "title": "Skipped Querylog Records",
+        "vizConfig": {
+          "group": "stat",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": 0
+                    },
+                    {
+                      "color": "orange",
+                      "value": 1
+                    },
+                    {
+                      "color": "red",
+                      "value": 10
+                    }
+                  ]
+                },
+                "unit": "short"
+              },
+              "overrides": []
+            },
+            "options": {
+              "colorMode": "background",
+              "graphMode": "none",
+              "justifyMode": "auto",
+              "orientation": "auto",
+              "percentChangeColorMode": "standard",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": false
+              },
+              "showPercentChange": false,
+              "textMode": "auto",
+              "wideLayout": true
+            }
+          },
+          "version": "13.0.1"
+        }
+      }
+    },
+    "panel-16": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "$datasource"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "editorMode": "code",
+                      "expr": "sum by (reason) (increase(agh_dns_filtering_reason_total{job=~\"$job\", namespace=~\"$namespace\", instance=~\"$instance\"}[$__range]))",
+                      "legendFormat": "{{reason}}",
+                      "range": true
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "A"
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "AdGuard filtering result reasons as parsed from querylog Result.Reason.",
+        "id": 16,
+        "links": [],
+        "title": "Filtering Reasons",
+        "vizConfig": {
+          "group": "piechart",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  }
+                },
+                "unit": "short"
+              },
+              "overrides": []
+            },
+            "options": {
+              "displayLabels": [
+                "name"
+              ],
+              "legend": {
+                "displayMode": "table",
+                "placement": "right",
+                "showLegend": true,
+                "values": [
+                  "percent",
+                  "value"
+                ]
+              },
+              "pieType": "pie",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": false
+              },
+              "sort": "desc",
+              "tooltip": {
+                "hideZeros": false,
+                "maxHeight": 600,
+                "mode": "single",
+                "sort": "none"
               }
             }
           },
@@ -1078,6 +855,7 @@
                   "axisLabel": "",
                   "axisPlacement": "auto",
                   "barAlignment": 0,
+                  "barWidthFactor": 0.6,
                   "drawStyle": "line",
                   "fillOpacity": 0,
                   "gradientMode": "none",
@@ -1094,6 +872,7 @@
                     "type": "linear"
                   },
                   "showPoints": "auto",
+                  "showValues": false,
                   "spanNulls": false,
                   "stacking": {
                     "group": "A",
@@ -1103,7 +882,6 @@
                     "mode": "off"
                   }
                 },
-                "mappings": [],
                 "min": 0,
                 "thresholds": {
                   "mode": "absolute",
@@ -1123,6 +901,10 @@
               "overrides": []
             },
             "options": {
+              "annotations": {
+                "clustering": -1,
+                "multiLane": false
+              },
               "legend": {
                 "calcs": [
                   "lastNotNull"
@@ -1132,14 +914,376 @@
                 "showLegend": true
               },
               "tooltip": {
+                "hideZeros": false,
                 "maxHeight": 600,
                 "mode": "single",
-                "sort": "none",
-                "hideZeros": false
+                "sort": "none"
+              }
+            }
+          },
+          "version": "13.0.1"
+        }
+      }
+    },
+    "panel-2": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "$datasource"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "editorMode": "code",
+                      "expr": "sum(increase(agh_dns_queries_total{job=~\"$job\", namespace=~\"$namespace\", instance=~\"$instance\"}[$__range]))",
+                      "legendFormat": "Queries",
+                      "range": true
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "A"
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "Valid AdGuard querylog entries processed during the selected dashboard time range. Skipped records are excluded.",
+        "id": 2,
+        "links": [],
+        "title": "Queries In Range",
+        "vizConfig": {
+          "group": "stat",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": 0
+                    }
+                  ]
+                },
+                "unit": "short"
               },
+              "overrides": []
+            },
+            "options": {
+              "colorMode": "background",
+              "graphMode": "none",
+              "justifyMode": "auto",
+              "orientation": "auto",
+              "percentChangeColorMode": "standard",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": false
+              },
+              "showPercentChange": false,
+              "textMode": "auto",
+              "wideLayout": true
+            }
+          },
+          "version": "13.0.1"
+        }
+      }
+    },
+    "panel-4": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "$datasource"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "editorMode": "code",
+                      "expr": "sum(increase(agh_blocked_dns_queries_total{job=~\"$job\", namespace=~\"$namespace\", instance=~\"$instance\"}[$__range]))",
+                      "legendFormat": "Blocked queries",
+                      "range": true
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "A"
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "Queries blocked by AdGuard blocklist or blocked-service reasons during the selected dashboard time range. Safe search, safe browsing, parental filtering, and rewrites are tracked separately by filtering reason.",
+        "id": 4,
+        "links": [],
+        "title": "Blocked In Range",
+        "vizConfig": {
+          "group": "stat",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "orange",
+                      "value": 0
+                    }
+                  ]
+                },
+                "unit": "short"
+              },
+              "overrides": []
+            },
+            "options": {
+              "colorMode": "background",
+              "graphMode": "none",
+              "justifyMode": "auto",
+              "orientation": "auto",
+              "percentChangeColorMode": "standard",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": false
+              },
+              "showPercentChange": false,
+              "textMode": "auto",
+              "wideLayout": true
+            }
+          },
+          "version": "13.0.1"
+        }
+      }
+    },
+    "panel-5": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "$datasource"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "editorMode": "code",
+                      "expr": "sum(increase(agh_blocked_dns_queries_total{job=~\"$job\", namespace=~\"$namespace\", instance=~\"$instance\"}[$__range])) / clamp_min(sum(increase(agh_dns_queries_total{job=~\"$job\", namespace=~\"$namespace\", instance=~\"$instance\"}[$__range])), 1) * 100",
+                      "legendFormat": "Blocked percentage",
+                      "range": true
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "A"
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "Blocked means AdGuard blocklist or blocked-service reasons.",
+        "id": 5,
+        "links": [],
+        "title": "Blocked Percentage",
+        "vizConfig": {
+          "group": "stat",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": 0
+                    },
+                    {
+                      "color": "orange",
+                      "value": 25
+                    },
+                    {
+                      "color": "red",
+                      "value": 50
+                    }
+                  ]
+                },
+                "unit": "percent"
+              },
+              "overrides": []
+            },
+            "options": {
+              "colorMode": "background",
+              "graphMode": "none",
+              "justifyMode": "auto",
+              "orientation": "auto",
+              "percentChangeColorMode": "standard",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": false
+              },
+              "showPercentChange": false,
+              "textMode": "auto",
+              "wideLayout": true
+            }
+          },
+          "version": "13.0.1"
+        }
+      }
+    },
+    "panel-6": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "$datasource"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "editorMode": "code",
+                      "expr": "sum(rate(agh_blocked_dns_queries_total{job=~\"$job\", namespace=~\"$namespace\", instance=~\"$instance\"}[$__rate_interval])) / clamp_min(sum(rate(agh_dns_queries_total{job=~\"$job\", namespace=~\"$namespace\", instance=~\"$instance\"}[$__rate_interval])), 0.001) * 100",
+                      "legendFormat": "Blocked percentage",
+                      "range": true
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "A"
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "Blocked means AdGuard blocklist or blocked-service reasons.",
+        "id": 6,
+        "links": [],
+        "title": "Blocked Query Rate",
+        "vizConfig": {
+          "group": "timeseries",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "continuous-GrYlRd",
+                  "seriesBy": "last"
+                },
+                "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "barWidthFactor": 0.6,
+                  "drawStyle": "line",
+                  "fillOpacity": 15,
+                  "gradientMode": "scheme",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "smooth",
+                  "lineWidth": 2,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "auto",
+                  "showValues": false,
+                  "spanNulls": false,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "off"
+                  }
+                },
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": 0
+                    },
+                    {
+                      "color": "red",
+                      "value": 80
+                    }
+                  ]
+                },
+                "unit": "percent"
+              },
+              "overrides": []
+            },
+            "options": {
               "annotations": {
                 "clustering": -1,
                 "multiLane": false
+              },
+              "legend": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "displayMode": "list",
+                "placement": "bottom",
+                "showLegend": true
+              },
+              "tooltip": {
+                "hideZeros": false,
+                "maxHeight": 600,
+                "mode": "single",
+                "sort": "none"
               }
             }
           },
@@ -1218,7 +1362,7 @@
             ]
           }
         },
-        "description": "",
+        "description": "Current top unfiltered query hosts tracked by the exporter since startup or initial querylog load. This is a current top-N snapshot, not a time-range increase.",
         "id": 7,
         "links": [],
         "title": "Top 100 Hosts",
@@ -1233,12 +1377,11 @@
                   "cellOptions": {
                     "type": "auto"
                   },
-                  "inspect": false,
                   "footer": {
                     "reducers": []
-                  }
+                  },
+                  "inspect": false
                 },
-                "mappings": [],
                 "thresholds": {
                   "mode": "absolute",
                   "steps": [
@@ -1332,7 +1475,7 @@
             ]
           }
         },
-        "description": "",
+        "description": "Current top hosts blocked by AdGuard blocklist or blocked-service reasons since startup or initial querylog load.",
         "id": 8,
         "links": [],
         "title": "Top 100 Blocked Hosts",
@@ -1347,126 +1490,11 @@
                   "cellOptions": {
                     "type": "auto"
                   },
-                  "inspect": false,
                   "footer": {
                     "reducers": []
-                  }
-                },
-                "mappings": [],
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green",
-                      "value": 0
-                    }
-                  ]
-                },
-                "unit": "short"
-              },
-              "overrides": []
-            },
-            "options": {
-              "cellHeight": "sm",
-              "showHeader": true
-            }
-          },
-          "version": "13.0.1"
-        }
-      }
-    },
-    "panel-11": {
-      "kind": "Panel",
-      "spec": {
-        "data": {
-          "kind": "QueryGroup",
-          "spec": {
-            "queries": [
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "$datasource"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "editorMode": "code",
-                      "expr": "topk(100, sum by (host) (agh_safe_search_enforced_hosts_total{job=~\"$job\", namespace=~\"$namespace\", instance=~\"$instance\"}) and on (host) (agh_safe_search_enforced_hosts_created{job=~\"$job\", namespace=~\"$namespace\", instance=~\"$instance\"} >= $metrics_start_time))",
-                      "format": "table",
-                      "instant": true,
-                      "legendFormat": "__auto",
-                      "range": false
-                    },
-                    "version": "v0"
                   },
-                  "refId": "A"
-                }
-              }
-            ],
-            "queryOptions": {},
-            "transformations": [
-              {
-                "group": "organize",
-                "kind": "Transformation",
-                "spec": {
-                  "options": {
-                    "excludeByName": {
-                      "Time": true,
-                      "__name__": true,
-                      "instance": true,
-                      "job": true,
-                      "namespace": true
-                    },
-                    "indexByName": {},
-                    "renameByName": {
-                      "Value": "Total queries",
-                      "host": "Host"
-                    }
-                  }
-                }
-              },
-              {
-                "group": "sortBy",
-                "kind": "Transformation",
-                "spec": {
-                  "options": {
-                    "fields": {},
-                    "sort": [
-                      {
-                        "desc": true,
-                        "field": "Total queries"
-                      }
-                    ]
-                  }
-                }
-              }
-            ]
-          }
-        },
-        "description": "",
-        "id": 11,
-        "links": [],
-        "title": "Safe Search Enforced Hosts",
-        "vizConfig": {
-          "group": "table",
-          "kind": "VizConfig",
-          "spec": {
-            "fieldConfig": {
-              "defaults": {
-                "custom": {
-                  "align": "auto",
-                  "cellOptions": {
-                    "type": "auto"
-                  },
-                  "inspect": false,
-                  "footer": {
-                    "reducers": []
-                  }
+                  "inspect": false
                 },
-                "mappings": [],
                 "thresholds": {
                   "mode": "absolute",
                   "steps": [
@@ -1502,21 +1530,8 @@
               "name": "panel-2"
             },
             "height": 4,
-            "width": 6,
+            "width": 3,
             "x": 0,
-            "y": 0
-          }
-        },
-        {
-          "kind": "GridLayoutItem",
-          "spec": {
-            "element": {
-              "kind": "ElementReference",
-              "name": "panel-4"
-            },
-            "height": 4,
-            "width": 6,
-            "x": 6,
             "y": 0
           }
         },
@@ -1528,6 +1543,32 @@
               "name": "panel-5"
             },
             "height": 4,
+            "width": 3,
+            "x": 3,
+            "y": 0
+          }
+        },
+        {
+          "kind": "GridLayoutItem",
+          "spec": {
+            "element": {
+              "kind": "ElementReference",
+              "name": "panel-10"
+            },
+            "height": 8,
+            "width": 6,
+            "x": 6,
+            "y": 0
+          }
+        },
+        {
+          "kind": "GridLayoutItem",
+          "spec": {
+            "element": {
+              "kind": "ElementReference",
+              "name": "panel-16"
+            },
+            "height": 8,
             "width": 6,
             "x": 12,
             "y": 0
@@ -1538,12 +1579,51 @@
           "spec": {
             "element": {
               "kind": "ElementReference",
-              "name": "panel-15"
+              "name": "panel-17"
             },
-            "height": 4,
+            "height": 8,
             "width": 6,
             "x": 18,
             "y": 0
+          }
+        },
+        {
+          "kind": "GridLayoutItem",
+          "spec": {
+            "element": {
+              "kind": "ElementReference",
+              "name": "panel-4"
+            },
+            "height": 4,
+            "width": 3,
+            "x": 0,
+            "y": 4
+          }
+        },
+        {
+          "kind": "GridLayoutItem",
+          "spec": {
+            "element": {
+              "kind": "ElementReference",
+              "name": "panel-15"
+            },
+            "height": 4,
+            "width": 3,
+            "x": 3,
+            "y": 4
+          }
+        },
+        {
+          "kind": "GridLayoutItem",
+          "spec": {
+            "element": {
+              "kind": "ElementReference",
+              "name": "panel-12"
+            },
+            "height": 8,
+            "width": 12,
+            "x": 0,
+            "y": 8
           }
         },
         {
@@ -1555,60 +1635,8 @@
             },
             "height": 8,
             "width": 12,
-            "x": 0,
-            "y": 4
-          }
-        },
-        {
-          "kind": "GridLayoutItem",
-          "spec": {
-            "element": {
-              "kind": "ElementReference",
-              "name": "panel-6"
-            },
-            "height": 8,
-            "width": 12,
             "x": 12,
-            "y": 4
-          }
-        },
-        {
-          "kind": "GridLayoutItem",
-          "spec": {
-            "element": {
-              "kind": "ElementReference",
-              "name": "panel-10"
-            },
-            "height": 8,
-            "width": 8,
-            "x": 0,
-            "y": 12
-          }
-        },
-        {
-          "kind": "GridLayoutItem",
-          "spec": {
-            "element": {
-              "kind": "ElementReference",
-              "name": "panel-16"
-            },
-            "height": 8,
-            "width": 8,
-            "x": 8,
-            "y": 12
-          }
-        },
-        {
-          "kind": "GridLayoutItem",
-          "spec": {
-            "element": {
-              "kind": "ElementReference",
-              "name": "panel-12"
-            },
-            "height": 8,
-            "width": 8,
-            "x": 16,
-            "y": 12
+            "y": 8
           }
         },
         {
@@ -1621,7 +1649,7 @@
             "height": 8,
             "width": 12,
             "x": 0,
-            "y": 20
+            "y": 16
           }
         },
         {
@@ -1629,12 +1657,12 @@
           "spec": {
             "element": {
               "kind": "ElementReference",
-              "name": "panel-17"
+              "name": "panel-6"
             },
             "height": 8,
             "width": 12,
             "x": 12,
-            "y": 20
+            "y": 16
           }
         },
         {
@@ -1644,10 +1672,10 @@
               "kind": "ElementReference",
               "name": "panel-7"
             },
-            "height": 15,
+            "height": 27,
             "width": 8,
             "x": 0,
-            "y": 28
+            "y": 24
           }
         },
         {
@@ -1657,10 +1685,10 @@
               "kind": "ElementReference",
               "name": "panel-8"
             },
-            "height": 15,
+            "height": 27,
             "width": 8,
             "x": 8,
-            "y": 28
+            "y": 24
           }
         },
         {
@@ -1670,10 +1698,10 @@
               "kind": "ElementReference",
               "name": "panel-11"
             },
-            "height": 15,
+            "height": 27,
             "width": 8,
             "x": 16,
-            "y": 28
+            "y": 24
           }
         }
       ]
@@ -1713,7 +1741,7 @@
       "1d"
     ],
     "fiscalYearStartMonth": 0,
-    "from": "now-3h",
+    "from": "now-1h",
     "hideTimepicker": false,
     "timezone": "utc",
     "to": "now"
@@ -1742,6 +1770,7 @@
     {
       "kind": "QueryVariable",
       "spec": {
+        "allValue": ".*",
         "allowCustomValue": true,
         "current": {
           "text": "All",
@@ -1772,13 +1801,13 @@
         "regex": "",
         "regexApplyTo": "value",
         "skipUrlSync": false,
-        "sort": "alphabeticalAsc",
-        "allValue": ".*"
+        "sort": "alphabeticalAsc"
       }
     },
     {
       "kind": "QueryVariable",
       "spec": {
+        "allValue": ".*",
         "allowCustomValue": true,
         "current": {
           "text": "All",
@@ -1809,13 +1838,13 @@
         "regex": "",
         "regexApplyTo": "value",
         "skipUrlSync": false,
-        "sort": "alphabeticalAsc",
-        "allValue": ".*"
+        "sort": "alphabeticalAsc"
       }
     },
     {
       "kind": "QueryVariable",
       "spec": {
+        "allValue": ".*",
         "allowCustomValue": true,
         "current": {
           "text": "All",
@@ -1846,8 +1875,7 @@
         "regex": "",
         "regexApplyTo": "value",
         "skipUrlSync": false,
-        "sort": "alphabeticalAsc",
-        "allValue": ".*"
+        "sort": "alphabeticalAsc"
       }
     },
     {
@@ -1855,8 +1883,8 @@
       "spec": {
         "allowCustomValue": true,
         "current": {
-          "text": "",
-          "value": ""
+          "text": "1777674062.8618844",
+          "value": "1777674062.8618844"
         },
         "definition": "query_result(scalar(min(agh_dns_queries_created{job=~\"$job\", namespace=~\"$namespace\", instance=~\"$instance\"})))",
         "hide": "hideVariable",

--- a/loghandler/loghandler_test.go
+++ b/loghandler/loghandler_test.go
@@ -474,6 +474,7 @@ func resetMetricsForLogHandlerTest(t *testing.T) {
 	oldQueryTypes := metrics.QueryTypes
 	oldTopQueryHosts := metrics.TopQueryHosts
 	oldTopBlockedQueryHosts := metrics.TopBlockedQueryHosts
+	oldTopFilteringReasonHosts := metrics.TopFilteringReasonHosts
 	oldSafeSearchEnforcedHosts := metrics.SafeSearchEnforcedHosts
 	oldQueryFilteringReasons := metrics.QueryFilteringReasons
 	oldQueryLogEntriesSkipped := metrics.QueryLogEntriesSkipped
@@ -485,6 +486,7 @@ func resetMetricsForLogHandlerTest(t *testing.T) {
 		metrics.QueryTypes = oldQueryTypes
 		metrics.TopQueryHosts = oldTopQueryHosts
 		metrics.TopBlockedQueryHosts = oldTopBlockedQueryHosts
+		metrics.TopFilteringReasonHosts = oldTopFilteringReasonHosts
 		metrics.SafeSearchEnforcedHosts = oldSafeSearchEnforcedHosts
 		metrics.QueryFilteringReasons = oldQueryFilteringReasons
 		metrics.QueryLogEntriesSkipped = oldQueryLogEntriesSkipped
@@ -512,6 +514,10 @@ func resetMetricsForLogHandlerTest(t *testing.T) {
 		Name: "agh_blocked_dns_query_hosts_total",
 		Help: "Top blocked DNS query hosts",
 	}, []string{"host"})
+	metrics.TopFilteringReasonHosts = metrics.NewCustomCounterVec(prometheus.CounterOpts{
+		Name: "agh_dns_filtering_reason_hosts_total",
+		Help: "Top DNS filtering reason hosts",
+	}, []string{"host", "reason"})
 	metrics.SafeSearchEnforcedHosts = metrics.NewCustomCounterVec(prometheus.CounterOpts{
 		Name: "agh_safe_search_enforced_hosts_total",
 		Help: "Safe search enforced hosts",

--- a/main.go
+++ b/main.go
@@ -35,6 +35,7 @@ func main() {
 	prometheus.MustRegister(metrics.QueryTypes.CounterVec, metrics.QueryTypes.CreatedVec)
 	prometheus.MustRegister(metrics.TopQueryHosts.CounterVec, metrics.TopQueryHosts.CreatedVec)
 	prometheus.MustRegister(metrics.TopBlockedQueryHosts.CounterVec, metrics.TopBlockedQueryHosts.CreatedVec)
+	prometheus.MustRegister(metrics.TopFilteringReasonHosts.CounterVec, metrics.TopFilteringReasonHosts.CreatedVec)
 	prometheus.MustRegister(metrics.SafeSearchEnforcedHosts.CounterVec, metrics.SafeSearchEnforcedHosts.CreatedVec)
 	prometheus.MustRegister(metrics.QueryFilteringReasons.CounterVec, metrics.QueryFilteringReasons.CreatedVec)
 	prometheus.MustRegister(metrics.QueryLogEntriesSkipped.CounterVec, metrics.QueryLogEntriesSkipped.CreatedVec)

--- a/metrics/collector.go
+++ b/metrics/collector.go
@@ -29,6 +29,10 @@ var (
 		Name: "agh_blocked_dns_query_hosts_total",
 		Help: "Top blocked DNS query hosts",
 	}, []string{"host"})
+	TopFilteringReasonHosts = NewCustomCounterVec(prometheus.CounterOpts{
+		Name: "agh_dns_filtering_reason_hosts_total",
+		Help: "Top DNS filtering reason hosts",
+	}, []string{"host", "reason"})
 	SafeSearchEnforcedHosts = NewCustomCounterVec(prometheus.CounterOpts{
 		Name: "agh_safe_search_enforced_hosts_total",
 		Help: "Safe search enforced hosts",
@@ -52,22 +56,24 @@ var (
 )
 
 type MetricsCollector struct {
-	topHosts              *TopHosts
-	topBlockedHosts       *TopHosts
-	responseTimes         []TimeValue
-	upstreamResponseTimes map[string][]TimeValue
-	windowSize            int64
-	processLock           sync.Mutex
-	lock                  sync.Mutex
+	topHosts                *TopHosts
+	topBlockedHosts         *TopHosts
+	topFilteringReasonHosts *TopHostReasons
+	responseTimes           []TimeValue
+	upstreamResponseTimes   map[string][]TimeValue
+	windowSize              int64
+	processLock             sync.Mutex
+	lock                    sync.Mutex
 }
 
 func NewMetricsCollector() *MetricsCollector {
 	return &MetricsCollector{
-		topHosts:              NewTopHosts(100),
-		topBlockedHosts:       NewTopHosts(100),
-		responseTimes:         make([]TimeValue, 0),
-		upstreamResponseTimes: make(map[string][]TimeValue),
-		windowSize:            300, // 5 minute window
+		topHosts:                NewTopHosts(100),
+		topBlockedHosts:         NewTopHosts(100),
+		topFilteringReasonHosts: NewTopHostReasons(100),
+		responseTimes:           make([]TimeValue, 0),
+		upstreamResponseTimes:   make(map[string][]TimeValue),
+		windowSize:              300, // 5 minute window
 	}
 }
 
@@ -103,6 +109,9 @@ func (mc *MetricsCollector) UpdateMetrics(entry QueryLogEntry) {
 	} else if reason.IsBlocked() {
 		BlockedQueries.Inc()
 		mc.topBlockedHosts.Add(entry.QHost)
+	}
+	if reason.IsFiltered() {
+		mc.topFilteringReasonHosts.Add(entry.QHost, reason.Label())
 	}
 
 	mc.ProcessMetrics()
@@ -146,6 +155,11 @@ func (mc *MetricsCollector) ProcessMetrics() {
 	TopBlockedQueryHosts.CounterVec.Reset()
 	for _, hc := range mc.topBlockedHosts.GetTop() {
 		TopBlockedQueryHosts.WithLabelValues(hc.Host).Add(float64(hc.Count))
+	}
+
+	TopFilteringReasonHosts.CounterVec.Reset()
+	for _, hc := range mc.topFilteringReasonHosts.GetTop() {
+		TopFilteringReasonHosts.WithLabelValues(hc.Host, hc.Reason).Add(float64(hc.Count))
 	}
 
 	mc.lock.Lock()

--- a/metrics/collector_test.go
+++ b/metrics/collector_test.go
@@ -82,6 +82,30 @@ func TestUpdateMetricsTracksBlockedQuerySeparately(t *testing.T) {
 	}
 }
 
+func TestUpdateMetricsTracksFilteredHostReasons(t *testing.T) {
+	resetMetricsForTest(t)
+	collector := NewMetricsCollector()
+
+	collector.UpdateMetrics(queryLogEntry("blocked.example", "A", true, ReasonFilteredBlockList, 10_000_000, "9.9.9.9"))
+	collector.UpdateMetrics(queryLogEntry("blocked.example", "A", true, ReasonFilteredBlockList, 20_000_000, "9.9.9.9"))
+	collector.UpdateMetrics(queryLogEntry("safe.example", "A", true, ReasonFilteredSafeSearch, 15_000_000, "8.8.8.8"))
+	collector.UpdateMetrics(queryLogEntry("allowed.example", "A", false, ReasonNotFilteredNotFound, 25_000_000, "1.1.1.1"))
+	collector.UpdateMetrics(queryLogEntry("rewritten.example", "A", false, ReasonRewritten, 25_000_000, "1.1.1.1"))
+
+	if got := testutil.ToFloat64(TopFilteringReasonHosts.WithLabelValues("blocked.example", "filtered_blocklist")); got != 2 {
+		t.Fatalf("expected blocked host reason count 2, got %f", got)
+	}
+	if got := testutil.ToFloat64(TopFilteringReasonHosts.WithLabelValues("safe.example", "filtered_safe_search")); got != 1 {
+		t.Fatalf("expected safe search host reason count 1, got %f", got)
+	}
+	if got := testutil.ToFloat64(TopFilteringReasonHosts.WithLabelValues("allowed.example", "not_filtered_not_found")); got != 0 {
+		t.Fatalf("expected allowed host not to be counted by filtered host reasons, got %f", got)
+	}
+	if got := testutil.ToFloat64(TopFilteringReasonHosts.WithLabelValues("rewritten.example", "rewritten")); got != 0 {
+		t.Fatalf("expected rewritten host not to be counted by filtered host reasons, got %f", got)
+	}
+}
+
 func TestUpdateMetricsTracksSafeSearchSeparatelyFromBlockedQueries(t *testing.T) {
 	resetMetricsForTest(t)
 	collector := NewMetricsCollector()
@@ -311,6 +335,7 @@ func resetMetricsForTest(t *testing.T) {
 	oldQueryTypes := QueryTypes
 	oldTopQueryHosts := TopQueryHosts
 	oldTopBlockedQueryHosts := TopBlockedQueryHosts
+	oldTopFilteringReasonHosts := TopFilteringReasonHosts
 	oldSafeSearchEnforcedHosts := SafeSearchEnforcedHosts
 	oldQueryFilteringReasons := QueryFilteringReasons
 	oldQueryLogEntriesSkipped := QueryLogEntriesSkipped
@@ -322,6 +347,7 @@ func resetMetricsForTest(t *testing.T) {
 		QueryTypes = oldQueryTypes
 		TopQueryHosts = oldTopQueryHosts
 		TopBlockedQueryHosts = oldTopBlockedQueryHosts
+		TopFilteringReasonHosts = oldTopFilteringReasonHosts
 		SafeSearchEnforcedHosts = oldSafeSearchEnforcedHosts
 		QueryFilteringReasons = oldQueryFilteringReasons
 		QueryLogEntriesSkipped = oldQueryLogEntriesSkipped
@@ -349,6 +375,10 @@ func resetMetricsForTest(t *testing.T) {
 		Name: "agh_blocked_dns_query_hosts_total",
 		Help: "Top blocked DNS query hosts",
 	}, []string{"host"})
+	TopFilteringReasonHosts = NewCustomCounterVec(prometheus.CounterOpts{
+		Name: "agh_dns_filtering_reason_hosts_total",
+		Help: "Top DNS filtering reason hosts",
+	}, []string{"host", "reason"})
 	SafeSearchEnforcedHosts = NewCustomCounterVec(prometheus.CounterOpts{
 		Name: "agh_safe_search_enforced_hosts_total",
 		Help: "Safe search enforced hosts",

--- a/metrics/querylog_entry.go
+++ b/metrics/querylog_entry.go
@@ -116,6 +116,13 @@ func (r FilteringReason) IsBlocked() bool {
 
 func (r FilteringReason) IsFiltered() bool {
 	switch r {
+	case ReasonNotFilteredNotFound,
+		ReasonNotFilteredAllowList,
+		ReasonNotFilteredError,
+		ReasonRewritten,
+		ReasonRewrittenAutoHosts,
+		ReasonRewrittenRule:
+		return false
 	case ReasonFilteredBlockList,
 		ReasonFilteredSafeBrowsing,
 		ReasonFilteredParental,

--- a/metrics/querylog_entry.go
+++ b/metrics/querylog_entry.go
@@ -114,6 +114,20 @@ func (r FilteringReason) IsBlocked() bool {
 	return r == ReasonFilteredBlockList || r == ReasonFilteredBlockedService
 }
 
+func (r FilteringReason) IsFiltered() bool {
+	switch r {
+	case ReasonFilteredBlockList,
+		ReasonFilteredSafeBrowsing,
+		ReasonFilteredParental,
+		ReasonFilteredInvalid,
+		ReasonFilteredSafeSearch,
+		ReasonFilteredBlockedService:
+		return true
+	default:
+		return false
+	}
+}
+
 func (r FilteringReason) IsSafeSearch() bool {
 	return r == ReasonFilteredSafeSearch
 }

--- a/metrics/top_hosts.go
+++ b/metrics/top_hosts.go
@@ -10,10 +10,28 @@ type HostCount struct {
 	Count int
 }
 
+type HostReasonCount struct {
+	Host   string
+	Reason string
+	Count  int
+}
+
+type HostReasonKey struct {
+	Host   string
+	Reason string
+}
+
 type TopHosts struct {
 	maxSize int
 	counter map[string]int
 	heap    HostCountHeap
+	lock    sync.Mutex
+}
+
+type TopHostReasons struct {
+	maxSize int
+	counter map[HostReasonKey]int
+	heap    HostReasonCountHeap
 	lock    sync.Mutex
 }
 
@@ -22,6 +40,14 @@ func NewTopHosts(maxSize int) *TopHosts {
 		maxSize: maxSize,
 		counter: make(map[string]int),
 		heap:    make(HostCountHeap, 0, maxSize),
+	}
+}
+
+func NewTopHostReasons(maxSize int) *TopHostReasons {
+	return &TopHostReasons{
+		maxSize: maxSize,
+		counter: make(map[HostReasonKey]int),
+		heap:    make(HostReasonCountHeap, 0, maxSize),
 	}
 }
 
@@ -57,6 +83,39 @@ func (th *TopHosts) GetTop() []HostCount {
 	return result
 }
 
+func (thr *TopHostReasons) Add(host, reason string) {
+	thr.lock.Lock()
+	defer thr.lock.Unlock()
+
+	key := HostReasonKey{Host: host, Reason: reason}
+	thr.counter[key]++
+	count := thr.counter[key]
+
+	for i, hc := range thr.heap {
+		if hc.Host == host && hc.Reason == reason {
+			thr.heap = append(thr.heap[:i], thr.heap[i+1:]...)
+			heap.Init(&thr.heap)
+			break
+		}
+	}
+
+	if len(thr.heap) < thr.maxSize {
+		heap.Push(&thr.heap, HostReasonCount{Host: host, Reason: reason, Count: count})
+	} else if count > thr.heap[0].Count {
+		heap.Pop(&thr.heap)
+		heap.Push(&thr.heap, HostReasonCount{Host: host, Reason: reason, Count: count})
+	}
+}
+
+func (thr *TopHostReasons) GetTop() []HostReasonCount {
+	thr.lock.Lock()
+	defer thr.lock.Unlock()
+
+	result := make([]HostReasonCount, len(thr.heap))
+	copy(result, thr.heap)
+	return result
+}
+
 type HostCountHeap []HostCount
 
 func (h HostCountHeap) Len() int           { return len(h) }
@@ -72,6 +131,28 @@ func (h *HostCountHeap) Push(x interface{}) {
 }
 
 func (h *HostCountHeap) Pop() interface{} {
+	old := *h
+	n := len(old)
+	x := old[n-1]
+	*h = old[0 : n-1]
+	return x
+}
+
+type HostReasonCountHeap []HostReasonCount
+
+func (h HostReasonCountHeap) Len() int           { return len(h) }
+func (h HostReasonCountHeap) Less(i, j int) bool { return h[i].Count < h[j].Count }
+func (h HostReasonCountHeap) Swap(i, j int)      { h[i], h[j] = h[j], h[i] }
+
+func (h *HostReasonCountHeap) Push(x interface{}) {
+	hostReasonCount, ok := x.(HostReasonCount)
+	if !ok {
+		panic("HostReasonCountHeap.Push received non-HostReasonCount value")
+	}
+	*h = append(*h, hostReasonCount)
+}
+
+func (h *HostReasonCountHeap) Pop() interface{} {
 	old := *h
 	n := len(old)
 	x := old[n-1]

--- a/metrics/top_hosts_test.go
+++ b/metrics/top_hosts_test.go
@@ -47,6 +47,54 @@ func TestTopHostsUpdatesExistingHostCount(t *testing.T) {
 	}
 }
 
+func TestTopHostReasonsKeepsMostFrequentHostReasons(t *testing.T) {
+	topHostReasons := NewTopHostReasons(2)
+
+	topHostReasons.Add("one.example", "filtered_blocklist")
+	topHostReasons.Add("two.example", "filtered_blocklist")
+	topHostReasons.Add("two.example", "filtered_blocklist")
+	topHostReasons.Add("three.example", "filtered_safe_search")
+	topHostReasons.Add("three.example", "filtered_safe_search")
+	topHostReasons.Add("three.example", "filtered_safe_search")
+
+	got := hostReasonCountsByName(topHostReasons.GetTop())
+
+	if len(got) != 2 {
+		t.Fatalf("expected exactly 2 top host reasons, got %d: %#v", len(got), got)
+	}
+	if _, exists := got[HostReasonKey{Host: "one.example", Reason: "filtered_blocklist"}]; exists {
+		t.Fatalf("expected least frequent host reason to be evicted, got %#v", got)
+	}
+	if got[HostReasonKey{Host: "two.example", Reason: "filtered_blocklist"}] != 2 {
+		t.Fatalf("expected two.example filtered_blocklist count 2, got %d", got[HostReasonKey{Host: "two.example", Reason: "filtered_blocklist"}])
+	}
+	if got[HostReasonKey{Host: "three.example", Reason: "filtered_safe_search"}] != 3 {
+		t.Fatalf("expected three.example filtered_safe_search count 3, got %d", got[HostReasonKey{Host: "three.example", Reason: "filtered_safe_search"}])
+	}
+}
+
+func TestTopHostReasonsUpdatesExistingHostReasonCount(t *testing.T) {
+	topHostReasons := NewTopHostReasons(1)
+
+	topHostReasons.Add("one.example", "filtered_blocklist")
+	topHostReasons.Add("one.example", "filtered_blocklist")
+
+	got := topHostReasons.GetTop()
+
+	if len(got) != 1 {
+		t.Fatalf("expected one host reason, got %d", len(got))
+	}
+	if got[0].Host != "one.example" {
+		t.Fatalf("expected one.example, got %q", got[0].Host)
+	}
+	if got[0].Reason != "filtered_blocklist" {
+		t.Fatalf("expected filtered_blocklist, got %q", got[0].Reason)
+	}
+	if got[0].Count != 2 {
+		t.Fatalf("expected updated count 2, got %d", got[0].Count)
+	}
+}
+
 func TestHostCountHeapPushPanicsForNonHostCount(t *testing.T) {
 	var heap HostCountHeap
 
@@ -59,10 +107,30 @@ func TestHostCountHeapPushPanicsForNonHostCount(t *testing.T) {
 	heap.Push("not a host count")
 }
 
+func TestHostReasonCountHeapPushPanicsForNonHostReasonCount(t *testing.T) {
+	var heap HostReasonCountHeap
+
+	defer func() {
+		if recovered := recover(); recovered == nil {
+			t.Fatal("expected Push to panic for non-HostReasonCount value")
+		}
+	}()
+
+	heap.Push("not a host reason count")
+}
+
 func hostCountsByName(counts []HostCount) map[string]int {
 	result := make(map[string]int, len(counts))
 	for _, count := range counts {
 		result[count.Host] = count.Count
+	}
+	return result
+}
+
+func hostReasonCountsByName(counts []HostReasonCount) map[HostReasonKey]int {
+	result := make(map[HostReasonKey]int, len(counts))
+	for _, count := range counts {
+		result[HostReasonKey{Host: count.Host, Reason: count.Reason}] = count.Count
 	}
 	return result
 }


### PR DESCRIPTION
Summary:
- add a versioned Grafana V2 dashboard JSON source
- add agh_dns_filtering_reason_hosts_total for top filtered hosts by reason
- replace the safe-search-only table with a broader Top Filtered Hosts table
- trim maintainer-only release workflow detail from README

Checks:
- go test ./...
- go vet ./...
- npx --yes markdownlint-cli2@0.22.1 '**/*.md' '#node_modules'
- jq empty dashboards/adguard-exporter.v2.json