### PR TITLE
ci: remove qemu from docker builds

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,9 +61,6 @@ jobs:
             --certificate-oidc-issuer https://accounts.google.com \
             --certificate-identity keyless@distroless.iam.gserviceaccount.com
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
@@ -81,8 +78,8 @@ jobs:
             org.opencontainers.image.revision=${{ github.sha }}
             org.opencontainers.image.version=dev
             org.opencontainers.image.created=${{ github.event.pull_request.updated_at }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=adguard-exporter
+          cache-to: type=gha,scope=adguard-exporter,mode=max,ignore-error=true
 
   renovate:
     needs: detect

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -56,9 +56,6 @@ jobs:
             --certificate-oidc-issuer https://accounts.google.com \
             --certificate-identity keyless@distroless.iam.gserviceaccount.com
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
@@ -188,8 +185,8 @@ jobs:
             org.opencontainers.image.revision=${{ github.sha }}
             org.opencontainers.image.version=${{ steps.tags.outputs.version }}
             org.opencontainers.image.created=${{ steps.tags.outputs.created }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=adguard-exporter
+          cache-to: type=gha,scope=adguard-exporter,mode=max,ignore-error=true
 
       - name: Verify Docker manifests
         env:


### PR DESCRIPTION
Removes QEMU setup from CI and publish Docker builds. The Dockerfile already builds from the build platform and cross-compiles with TARGETOS/TARGETARCH, so Buildx can produce linux/amd64 and linux/arm64 images without emulated build steps.

Also makes the BuildKit GHA cache settings explicit and tolerant of cache export failures:
- cache-from: type=gha,scope=adguard-exporter
- cache-to: type=gha,scope=adguard-exporter,mode=max,ignore-error=true

Validation:
- actionlint -shellcheck=shellcheck .github/workflows/ci.yaml .github/workflows/publish.yaml
- docker buildx build --platform linux/amd64,linux/arm64 .
- git diff --check